### PR TITLE
[feature/exam-taking] ✨ feat : 쪽지시험 응시 상태/부정행위 API 및 테스트 추가

### DIFF
--- a/apps/exams/constants.py
+++ b/apps/exams/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ExamStatus(str, Enum):
+    CLOSED = "closed"
+    ACTIVATED = "activated"

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -5,6 +5,13 @@ from rest_framework.permissions import BasePermission
 from apps.users.models import User
 
 
+class IsStudentRole(BasePermission):
+    message = "권한이 없습니다."
+
+    def has_permission(self, request: Any, view: Any) -> bool:
+        user = request.user
+        return bool(user and user.is_authenticated and user.role == User.Role.STUDENT)
+
 class IsExamStaff(BasePermission):
     message = "쪽지시험 문제 등록 권한이 없습니다."
 

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -8,10 +8,10 @@ from apps.users.models import User
 class IsStudentRole(BasePermission):
     message = "권한이 없습니다."
 
-
     def has_permission(self, request: Any, view: Any) -> bool:
         user = request.user
         return bool(user and user.is_authenticated and user.role == User.Role.STUDENT)
+
 
 class IsExamStaff(BasePermission):
     message = "쪽지시험 문제 등록 권한이 없습니다."

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -8,6 +8,7 @@ from apps.users.models import User
 class IsStudentRole(BasePermission):
     message = "권한이 없습니다."
 
+
     def has_permission(self, request: Any, view: Any) -> bool:
         user = request.user
         return bool(user and user.is_authenticated and user.role == User.Role.STUDENT)

--- a/apps/exams/serializers/admin_question_serializers.py
+++ b/apps/exams/serializers/admin_question_serializers.py
@@ -26,6 +26,14 @@ class AdminExamQuestionCreateRequestSerializer(serializers.Serializer[Any]):
     explanation = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        type_map = {
+            "multiple_choice": ExamQuestion.TypeChoices.MULTI_SELECT,
+            "fill_blank": ExamQuestion.TypeChoices.FILL_IN_BLANK,
+            "ordering": ExamQuestion.TypeChoices.ORDERING,
+            "short_answer": ExamQuestion.TypeChoices.SHORT_ANSWER,
+            "ox": ExamQuestion.TypeChoices.OX,
+        }
+
         exam_type = attrs.get("type")
         if exam_type not in self.TYPE_MAP:
             raise serializers.ValidationError("유효하지 않은 문제 등록 데이터입니다.")

--- a/apps/exams/serializers/cheating_serializers.py
+++ b/apps/exams/serializers/cheating_serializers.py
@@ -9,3 +9,9 @@ class ExamCheatingResponseSerializer(ExamBaseResponseSerializer):
     """부정행위 카운트 응답 스키마."""
 
     cheating_count = serializers.IntegerField()
+
+
+class ExamCheatingRequestSerializer(serializers.Serializer[Any]):
+    """부정행위 카운트 요청 스키마."""
+
+    answers_json = serializers.JSONField(required=False)

--- a/apps/exams/serializers/cheating_serializers.py
+++ b/apps/exams/serializers/cheating_serializers.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.exams.serializers.status_serializers import ExamBaseResponseSerializer
+
+
+class ExamCheatingResponseSerializer(ExamBaseResponseSerializer):
+    """부정행위 카운트 응답 스키마."""
+
+    cheating_count = serializers.IntegerField()

--- a/apps/exams/serializers/error_serializers.py
+++ b/apps/exams/serializers/error_serializers.py
@@ -7,3 +7,9 @@ class ErrorResponseSerializer(serializers.Serializer[Any]):
     """에러 응답 스키마."""
 
     error_detail = serializers.CharField()
+
+
+class ErrorDetailSerializer(serializers.Serializer[Any]):
+    """권한/인증 에러 응답 스키마."""
+
+    detail = serializers.CharField()

--- a/apps/exams/serializers/status_serializers.py
+++ b/apps/exams/serializers/status_serializers.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class ExamBaseResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 공통 응답 스키마."""
+
+    exam_status = serializers.CharField()
+    force_submit = serializers.BooleanField()
+
+
+class ExamStatusResponseSerializer(ExamBaseResponseSerializer):
+    """쪽지시험 상태 응답 스키마."""

--- a/apps/exams/services/exam_status_service.py
+++ b/apps/exams/services/exam_status_service.py
@@ -1,30 +1,5 @@
-from typing import Any, cast
-
-from django.utils import timezone
-
-from apps.exams.models import ExamDeployment, ExamSubmission
-from apps.users.models import User
+from apps.exams.models import ExamDeployment
 
 
-def ensure_student_role(user: User) -> bool:
-    return user.role == User.Role.STUDENT
-
-
-def get_submission(user: User, deployment: ExamDeployment) -> ExamSubmission | None:
-    submission_model = cast(Any, ExamSubmission)
-    submission = submission_model.objects.filter(submitter=user, deployment=deployment).order_by("-created_at").first()
-    return cast(ExamSubmission | None, submission)
-
-
-def is_exam_closed(deployment: ExamDeployment, submission: ExamSubmission) -> bool:
-    now = timezone.now()
-    if deployment.status != ExamDeployment.StatusChoices.ACTIVATED:
-        return True
-    if submission.cheating_count >= 3:
-        return True
-    if deployment.close_at and now >= deployment.close_at:
-        return True
-    elapsed = now - submission.started_at
-    if elapsed.total_seconds() >= deployment.duration_time * 60:
-        return True
-    return False
+def is_exam_active(deployment: ExamDeployment) -> bool:
+    return deployment.status == ExamDeployment.StatusChoices.ACTIVATED

--- a/apps/exams/services/exam_status_service.py
+++ b/apps/exams/services/exam_status_service.py
@@ -1,0 +1,30 @@
+from typing import Any, cast
+
+from django.utils import timezone
+
+from apps.exams.models import ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+
+def ensure_student_role(user: User) -> bool:
+    return user.role == User.Role.STUDENT
+
+
+def get_submission(user: User, deployment: ExamDeployment) -> ExamSubmission | None:
+    submission_model = cast(Any, ExamSubmission)
+    submission = submission_model.objects.filter(submitter=user, deployment=deployment).order_by("-created_at").first()
+    return cast(ExamSubmission | None, submission)
+
+
+def is_exam_closed(deployment: ExamDeployment, submission: ExamSubmission) -> bool:
+    now = timezone.now()
+    if deployment.status != ExamDeployment.StatusChoices.ACTIVATED:
+        return True
+    if submission.cheating_count >= 3:
+        return True
+    if deployment.close_at and now >= deployment.close_at:
+        return True
+    elapsed = now - submission.started_at
+    if elapsed.total_seconds() >= deployment.duration_time * 60:
+        return True
+    return False

--- a/apps/exams/tests/test_cheating_views.py
+++ b/apps/exams/tests/test_cheating_views.py
@@ -1,6 +1,6 @@
-from datetime import date, datetime, timedelta
-from typing import Any, cast
+from datetime import date, timedelta
 
+from django.core.cache import cache
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework_simplejwt.tokens import AccessToken
@@ -8,47 +8,40 @@ from rest_framework_simplejwt.tokens import AccessToken
 from apps.courses.models.cohorts import Cohort
 from apps.courses.models.courses import Course
 from apps.courses.models.subjects import Subject
-from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.exams.models import Exam, ExamDeployment
 from apps.users.models import User
-
-CourseModel = cast(Any, Course)
-SubjectModel = cast(Any, Subject)
-CohortModel = cast(Any, Cohort)
-ExamModel = cast(Any, Exam)
-ExamDeploymentModel = cast(Any, ExamDeployment)
-ExamSubmissionModel = cast(Any, ExamSubmission)
 
 
 class ExamCheatingUpdateAPITest(TestCase):
     """쪽지시험 부정행위 업데이트 API 테스트."""
 
     def setUp(self) -> None:
-        self.course = CourseModel.objects.create(
+        self.course = Course.objects.create(
             name="코스",
             tag="CS",
             description="설명",
             thumbnail_img_url="course.png",
         )
-        self.subject = SubjectModel.objects.create(
+        self.subject = Subject.objects.create(
             course=self.course,
             title="과목",
             number_of_days=1,
             number_of_hours=1,
             thumbnail_img_url="subject.png",
         )
-        self.cohort = CohortModel.objects.create(
+        self.cohort = Cohort.objects.create(
             course=self.course,
             number=1,
             max_student=10,
             start_date=date.today(),
             end_date=date.today() + timedelta(days=30),
         )
-        self.exam = ExamModel.objects.create(
+        self.exam = Exam.objects.create(
             subject=self.subject,
             title="시험",
             thumbnail_img_url="exam.png",
         )
-        self.deployment = ExamDeploymentModel.objects.create(
+        self.deployment = ExamDeployment.objects.create(
             cohort=self.cohort,
             exam=self.exam,
             duration_time=30,
@@ -79,26 +72,18 @@ class ExamCheatingUpdateAPITest(TestCase):
             role=User.Role.USER,
         )
 
-    def _create_submission(self, started_at: datetime | None = None, cheating_count: int = 0) -> ExamSubmission:
-        return cast(
-            ExamSubmission,
-            ExamSubmissionModel.objects.create(
-                submitter=self.student,
-                deployment=self.deployment,
-                started_at=started_at or timezone.now(),
-                cheating_count=cheating_count,
-                answers_json={},
-                score=0,
-                correct_answer_count=0,
-            ),
-        )
-
     def _auth_headers(self, user: User) -> dict[str, str]:
         token = AccessToken.for_user(user)
         return {"Authorization": f"Bearer {token}"}
 
+    def _cache_key(self) -> str:
+        return f"exam:cheating:{self.deployment.id}:{self.student.id}"
+
+    def _clear_cache(self) -> None:
+        cache.delete(self._cache_key())
+
     def test_cheating_increments_count(self) -> None:
-        self._create_submission()
+        self._clear_cache()
         response = self.client.post(
             f"/api/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.student),
@@ -111,7 +96,13 @@ class ExamCheatingUpdateAPITest(TestCase):
         self.assertFalse(data["force_submit"])
 
     def test_cheating_returns_closed_when_reaching_limit(self) -> None:
-        submission = self._create_submission(cheating_count=2)
+        self._clear_cache()
+        for _ in range(2):
+            self.client.post(
+                f"/api/exams/deployments/{self.deployment.id}/cheating/",
+                headers=self._auth_headers(self.student),
+            )
+
         response = self.client.post(
             f"/api/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.student),
@@ -121,11 +112,9 @@ class ExamCheatingUpdateAPITest(TestCase):
         data = response.json()
         self.assertEqual(data["exam_status"], "closed")
         self.assertTrue(data["force_submit"])
-        submission.refresh_from_db()
-        self.assertEqual(submission.cheating_count, 3)
 
     def test_cheating_returns_403_for_non_student(self) -> None:
-        self._create_submission()
+        self._clear_cache()
         response = self.client.post(
             f"/api/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.other_user),
@@ -133,21 +122,10 @@ class ExamCheatingUpdateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         data = response.json()
-        self.assertEqual(data["error_detail"], "권한이 없습니다.")
-
-    def test_cheating_returns_400_without_submission(self) -> None:
-        response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
-            headers=self._auth_headers(self.student),
-        )
-
-        self.assertEqual(response.status_code, 400)
-        data = response.json()
-        self.assertEqual(data["error_detail"], "유효하지 않은 시험 응시 세션입니다.")
+        self.assertEqual(data["detail"], "권한이 없습니다.")
 
     def test_cheating_requires_authentication(self) -> None:
-        self._create_submission()
-
+        self._clear_cache()
         response = self.client.post(f"/api/exams/deployments/{self.deployment.id}/cheating/")
 
         self.assertEqual(response.status_code, 401)
@@ -155,7 +133,7 @@ class ExamCheatingUpdateAPITest(TestCase):
         self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
 
     def test_cheating_returns_404_when_deployment_missing(self) -> None:
-        self._create_submission()
+        self._clear_cache()
         response = self.client.post(
             "/api/exams/deployments/9999/cheating/",
             headers=self._auth_headers(self.student),
@@ -165,19 +143,8 @@ class ExamCheatingUpdateAPITest(TestCase):
         data = response.json()
         self.assertEqual(data["error_detail"], "해당 시험 정보를 찾을 수 없습니다.")
 
-    def test_cheating_returns_410_when_time_expired(self) -> None:
-        self._create_submission(started_at=timezone.now() - timedelta(minutes=60))
-        response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
-            headers=self._auth_headers(self.student),
-        )
-
-        self.assertEqual(response.status_code, 410)
-        data = response.json()
-        self.assertEqual(data["error_detail"], "시험이 이미 종료되었습니다.")
-
     def test_cheating_returns_410_when_deactivated(self) -> None:
-        self._create_submission()
+        self._clear_cache()
         self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
         self.deployment.save(update_fields=["status"])
 

--- a/apps/exams/tests/test_cheating_views.py
+++ b/apps/exams/tests/test_cheating_views.py
@@ -126,9 +126,7 @@ class ExamCheatingUpdateAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertTrue(data["force_submit"])
-        self.assertTrue(
-            ExamSubmission.objects.filter(submitter=self.student, deployment=self.deployment).exists()
-        )
+        self.assertTrue(ExamSubmission.objects.filter(submitter=self.student, deployment=self.deployment).exists())
 
     def test_cheating_returns_410_when_submission_exists(self) -> None:
         ExamSubmission.objects.create(

--- a/apps/exams/tests/test_cheating_views.py
+++ b/apps/exams/tests/test_cheating_views.py
@@ -1,0 +1,191 @@
+from datetime import date, datetime, timedelta
+from typing import Any, cast
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+CourseModel = cast(Any, Course)
+SubjectModel = cast(Any, Subject)
+CohortModel = cast(Any, Cohort)
+ExamModel = cast(Any, Exam)
+ExamDeploymentModel = cast(Any, ExamDeployment)
+ExamSubmissionModel = cast(Any, ExamSubmission)
+
+
+class ExamCheatingUpdateAPITest(TestCase):
+    """쪽지시험 부정행위 업데이트 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = CourseModel.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = SubjectModel.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = CohortModel.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = ExamModel.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.deployment = ExamDeploymentModel.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE",
+            open_at=timezone.now() - timedelta(minutes=5),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        self.student = User.objects.create_user(
+            email="student@example.com",
+            password="password123",
+            name="학생",
+            nickname="닉네임",
+            phone_number="01012345678",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.STUDENT,
+        )
+        self.other_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="닉네임2",
+            phone_number="01000000000",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+
+    def _create_submission(self, started_at: datetime | None = None, cheating_count: int = 0) -> ExamSubmission:
+        return cast(
+            ExamSubmission,
+            ExamSubmissionModel.objects.create(
+                submitter=self.student,
+                deployment=self.deployment,
+                started_at=started_at or timezone.now(),
+                cheating_count=cheating_count,
+                answers_json={},
+                score=0,
+                correct_answer_count=0,
+            ),
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_cheating_increments_count(self) -> None:
+        self._create_submission()
+        response = self.client.post(
+            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["cheating_count"], 1)
+        self.assertEqual(data["exam_status"], "activated")
+        self.assertFalse(data["force_submit"])
+
+    def test_cheating_returns_closed_when_reaching_limit(self) -> None:
+        submission = self._create_submission(cheating_count=2)
+        response = self.client.post(
+            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["exam_status"], "closed")
+        self.assertTrue(data["force_submit"])
+        submission.refresh_from_db()
+        self.assertEqual(submission.cheating_count, 3)
+
+    def test_cheating_returns_403_for_non_student(self) -> None:
+        self._create_submission()
+        response = self.client.post(
+            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            headers=self._auth_headers(self.other_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "권한이 없습니다.")
+
+    def test_cheating_returns_400_without_submission(self) -> None:
+        response = self.client.post(
+            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "유효하지 않은 시험 응시 세션입니다.")
+
+    def test_cheating_requires_authentication(self) -> None:
+        self._create_submission()
+
+        response = self.client.post(f"/api/exams/deployments/{self.deployment.id}/cheating/")
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_cheating_returns_404_when_deployment_missing(self) -> None:
+        self._create_submission()
+        response = self.client.post(
+            "/api/exams/deployments/9999/cheating/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "해당 시험 정보를 찾을 수 없습니다.")
+
+    def test_cheating_returns_410_when_time_expired(self) -> None:
+        self._create_submission(started_at=timezone.now() - timedelta(minutes=60))
+        response = self.client.post(
+            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 410)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "시험이 이미 종료되었습니다.")
+
+    def test_cheating_returns_410_when_deactivated(self) -> None:
+        self._create_submission()
+        self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
+        self.deployment.save(update_fields=["status"])
+
+        response = self.client.post(
+            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 410)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "시험이 이미 종료되었습니다.")

--- a/apps/exams/tests/test_status_views.py
+++ b/apps/exams/tests/test_status_views.py
@@ -1,5 +1,4 @@
-from datetime import date, datetime, timedelta
-from typing import Any, cast
+from datetime import date, timedelta
 
 from django.test import TestCase
 from django.utils import timezone
@@ -8,47 +7,40 @@ from rest_framework_simplejwt.tokens import AccessToken
 from apps.courses.models.cohorts import Cohort
 from apps.courses.models.courses import Course
 from apps.courses.models.subjects import Subject
-from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.exams.models import Exam, ExamDeployment
 from apps.users.models import User
-
-CourseModel = cast(Any, Course)
-SubjectModel = cast(Any, Subject)
-CohortModel = cast(Any, Cohort)
-ExamModel = cast(Any, Exam)
-ExamDeploymentModel = cast(Any, ExamDeployment)
-ExamSubmissionModel = cast(Any, ExamSubmission)
 
 
 class ExamStatusCheckAPITest(TestCase):
     """쪽지시험 상태 확인 API 테스트."""
 
     def setUp(self) -> None:
-        self.course = CourseModel.objects.create(
+        self.course = Course.objects.create(
             name="코스",
             tag="CS",
             description="설명",
             thumbnail_img_url="course.png",
         )
-        self.subject = SubjectModel.objects.create(
+        self.subject = Subject.objects.create(
             course=self.course,
             title="과목",
             number_of_days=1,
             number_of_hours=1,
             thumbnail_img_url="subject.png",
         )
-        self.cohort = CohortModel.objects.create(
+        self.cohort = Cohort.objects.create(
             course=self.course,
             number=1,
             max_student=10,
             start_date=date.today(),
             end_date=date.today() + timedelta(days=30),
         )
-        self.exam = ExamModel.objects.create(
+        self.exam = Exam.objects.create(
             subject=self.subject,
             title="시험",
             thumbnail_img_url="exam.png",
         )
-        self.deployment = ExamDeploymentModel.objects.create(
+        self.deployment = ExamDeployment.objects.create(
             cohort=self.cohort,
             exam=self.exam,
             duration_time=30,
@@ -79,26 +71,11 @@ class ExamStatusCheckAPITest(TestCase):
             role=User.Role.USER,
         )
 
-    def _create_submission(self, started_at: datetime | None = None, cheating_count: int = 0) -> ExamSubmission:
-        return cast(
-            ExamSubmission,
-            ExamSubmissionModel.objects.create(
-                submitter=self.student,
-                deployment=self.deployment,
-                started_at=started_at or timezone.now(),
-                cheating_count=cheating_count,
-                answers_json={},
-                score=0,
-                correct_answer_count=0,
-            ),
-        )
-
     def _auth_headers(self, user: User) -> dict[str, str]:
         token = AccessToken.for_user(user)
         return {"Authorization": f"Bearer {token}"}
 
     def test_status_returns_activated(self) -> None:
-        self._create_submission(started_at=timezone.now() - timedelta(minutes=1))
         response = self.client.get(
             f"/api/exams/deployments/{self.deployment.id}/status/",
             headers=self._auth_headers(self.student),
@@ -110,7 +87,6 @@ class ExamStatusCheckAPITest(TestCase):
         self.assertFalse(data["force_submit"])
 
     def test_status_returns_closed_when_closed(self) -> None:
-        self._create_submission(started_at=timezone.now() - timedelta(minutes=1))
         self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
         self.deployment.save(update_fields=["status"])
 
@@ -125,7 +101,6 @@ class ExamStatusCheckAPITest(TestCase):
         self.assertTrue(data["force_submit"])
 
     def test_status_returns_403_for_non_student(self) -> None:
-        self._create_submission()
         response = self.client.get(
             f"/api/exams/deployments/{self.deployment.id}/status/",
             headers=self._auth_headers(self.other_user),
@@ -133,21 +108,9 @@ class ExamStatusCheckAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         data = response.json()
-        self.assertEqual(data["error_detail"], "권한이 없습니다.")
-
-    def test_status_returns_400_without_submission(self) -> None:
-        response = self.client.get(
-            f"/api/exams/deployments/{self.deployment.id}/status/",
-            headers=self._auth_headers(self.student),
-        )
-
-        self.assertEqual(response.status_code, 400)
-        data = response.json()
-        self.assertEqual(data["error_detail"], "유효하지 않은 시험 응시 세션입니다.")
+        self.assertEqual(data["detail"], "권한이 없습니다.")
 
     def test_status_requires_authentication(self) -> None:
-        self._create_submission()
-
         response = self.client.get(f"/api/exams/deployments/{self.deployment.id}/status/")
 
         self.assertEqual(response.status_code, 401)
@@ -155,7 +118,6 @@ class ExamStatusCheckAPITest(TestCase):
         self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
 
     def test_status_returns_404_when_deployment_missing(self) -> None:
-        self._create_submission()
         response = self.client.get(
             "/api/exams/deployments/9999/status/",
             headers=self._auth_headers(self.student),
@@ -164,30 +126,3 @@ class ExamStatusCheckAPITest(TestCase):
         self.assertEqual(response.status_code, 404)
         data = response.json()
         self.assertEqual(data["error_detail"], "해당 시험 정보를 찾을 수 없습니다.")
-
-    def test_status_returns_closed_when_time_expired(self) -> None:
-        self._create_submission(started_at=timezone.now() - timedelta(minutes=60))
-        response = self.client.get(
-            f"/api/exams/deployments/{self.deployment.id}/status/",
-            headers=self._auth_headers(self.student),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(data["exam_status"], "closed")
-        self.assertTrue(data["force_submit"])
-
-    def test_status_returns_closed_when_close_at_passed(self) -> None:
-        self._create_submission(started_at=timezone.now())
-        self.deployment.close_at = timezone.now() - timedelta(minutes=1)
-        self.deployment.save(update_fields=["close_at"])
-
-        response = self.client.get(
-            f"/api/exams/deployments/{self.deployment.id}/status/",
-            headers=self._auth_headers(self.student),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(data["exam_status"], "closed")
-        self.assertTrue(data["force_submit"])

--- a/apps/exams/tests/test_status_views.py
+++ b/apps/exams/tests/test_status_views.py
@@ -1,0 +1,193 @@
+from datetime import date, datetime, timedelta
+from typing import Any, cast
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+CourseModel = cast(Any, Course)
+SubjectModel = cast(Any, Subject)
+CohortModel = cast(Any, Cohort)
+ExamModel = cast(Any, Exam)
+ExamDeploymentModel = cast(Any, ExamDeployment)
+ExamSubmissionModel = cast(Any, ExamSubmission)
+
+
+class ExamStatusCheckAPITest(TestCase):
+    """쪽지시험 상태 확인 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = CourseModel.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = SubjectModel.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = CohortModel.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = ExamModel.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.deployment = ExamDeploymentModel.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE",
+            open_at=timezone.now() - timedelta(minutes=5),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        self.student = User.objects.create_user(
+            email="student@example.com",
+            password="password123",
+            name="학생",
+            nickname="닉네임",
+            phone_number="01012345678",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.STUDENT,
+        )
+        self.other_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="닉네임2",
+            phone_number="01000000000",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+
+    def _create_submission(self, started_at: datetime | None = None, cheating_count: int = 0) -> ExamSubmission:
+        return cast(
+            ExamSubmission,
+            ExamSubmissionModel.objects.create(
+                submitter=self.student,
+                deployment=self.deployment,
+                started_at=started_at or timezone.now(),
+                cheating_count=cheating_count,
+                answers_json={},
+                score=0,
+                correct_answer_count=0,
+            ),
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_status_returns_activated(self) -> None:
+        self._create_submission(started_at=timezone.now() - timedelta(minutes=1))
+        response = self.client.get(
+            f"/api/exams/deployments/{self.deployment.id}/status/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["exam_status"], "activated")
+        self.assertFalse(data["force_submit"])
+
+    def test_status_returns_closed_when_closed(self) -> None:
+        self._create_submission(started_at=timezone.now() - timedelta(minutes=1))
+        self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
+        self.deployment.save(update_fields=["status"])
+
+        response = self.client.get(
+            f"/api/exams/deployments/{self.deployment.id}/status/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["exam_status"], "closed")
+        self.assertTrue(data["force_submit"])
+
+    def test_status_returns_403_for_non_student(self) -> None:
+        self._create_submission()
+        response = self.client.get(
+            f"/api/exams/deployments/{self.deployment.id}/status/",
+            headers=self._auth_headers(self.other_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "권한이 없습니다.")
+
+    def test_status_returns_400_without_submission(self) -> None:
+        response = self.client.get(
+            f"/api/exams/deployments/{self.deployment.id}/status/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "유효하지 않은 시험 응시 세션입니다.")
+
+    def test_status_requires_authentication(self) -> None:
+        self._create_submission()
+
+        response = self.client.get(f"/api/exams/deployments/{self.deployment.id}/status/")
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_status_returns_404_when_deployment_missing(self) -> None:
+        self._create_submission()
+        response = self.client.get(
+            "/api/exams/deployments/9999/status/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "해당 시험 정보를 찾을 수 없습니다.")
+
+    def test_status_returns_closed_when_time_expired(self) -> None:
+        self._create_submission(started_at=timezone.now() - timedelta(minutes=60))
+        response = self.client.get(
+            f"/api/exams/deployments/{self.deployment.id}/status/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["exam_status"], "closed")
+        self.assertTrue(data["force_submit"])
+
+    def test_status_returns_closed_when_close_at_passed(self) -> None:
+        self._create_submission(started_at=timezone.now())
+        self.deployment.close_at = timezone.now() - timedelta(minutes=1)
+        self.deployment.save(update_fields=["close_at"])
+
+        response = self.client.get(
+            f"/api/exams/deployments/{self.deployment.id}/status/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["exam_status"], "closed")
+        self.assertTrue(data["force_submit"])

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -1,7 +1,13 @@
 from django.urls import path
 
+from apps.exams.views.cheating_views import ExamCheatingUpdateAPIView
+from apps.exams.views.status_views import ExamStatusCheckAPIView
 from apps.exams.views.exam_list import ExamListView
 
+
 urlpatterns = [
+    path("deployments/<int:deployment_id>/status/", ExamStatusCheckAPIView.as_view(), name="exam-status"),
+    path("deployments/<int:deployment_id>/cheating/", ExamCheatingUpdateAPIView.as_view(), name="exam-cheating"),
     path("deployments", ExamListView.as_view(), name="exam-deployments"),
+
 ]

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     path("deployments/<int:deployment_id>/status/", ExamStatusCheckAPIView.as_view(), name="exam-status"),
     path("deployments/<int:deployment_id>/cheating/", ExamCheatingUpdateAPIView.as_view(), name="exam-cheating"),
     path("deployments", ExamListView.as_view(), name="exam-deployments"),
-
+    path("api/v1/exams/deployments", ExamListView.as_view(), name="exam-deployments"),
 ]

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -1,9 +1,8 @@
 from django.urls import path
 
 from apps.exams.views.cheating_views import ExamCheatingUpdateAPIView
-from apps.exams.views.status_views import ExamStatusCheckAPIView
 from apps.exams.views.exam_list import ExamListView
-
+from apps.exams.views.status_views import ExamStatusCheckAPIView
 
 urlpatterns = [
     path("deployments/<int:deployment_id>/status/", ExamStatusCheckAPIView.as_view(), name="exam-status"),

--- a/apps/exams/views/cheating_views.py
+++ b/apps/exams/views/cheating_views.py
@@ -1,5 +1,7 @@
 from typing import Any, cast
 
+from django.db import transaction
+from django.db.models import F
 from django.core.cache import cache
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema

--- a/apps/exams/views/cheating_views.py
+++ b/apps/exams/views/cheating_views.py
@@ -67,7 +67,7 @@ class ExamCheatingUpdateAPIView(APIView):
 
         cheating_key = f"exam:cheating:{deployment.id}:{user.id}"
         submit_lock_key = f"exam:submit-lock:{deployment.id}:{user.id}"
-        if ExamSubmission.objects.filter(submitter=user, deployment=deployment).exists():
+        if ExamSubmission.objects.filter(submitter_id=user.id, deployment=deployment).exists():
             return Response({"error_detail": "이미 제출된 시험입니다."}, status=410)
 
         current_count = cache.get(cheating_key)
@@ -89,7 +89,7 @@ class ExamCheatingUpdateAPIView(APIView):
             if cache.add(submit_lock_key, "1", timeout=5):
                 with transaction.atomic():
                     submission, created = ExamSubmission.objects.select_for_update().get_or_create(
-                        submitter=user,
+                        submitter_id=user.id,
                         deployment=deployment,
                         defaults={
                             "started_at": timezone.now(),

--- a/apps/exams/views/cheating_views.py
+++ b/apps/exams/views/cheating_views.py
@@ -1,0 +1,98 @@
+from typing import Any, cast
+
+from django.db import transaction
+from django.db.models import F
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.constants import ExamStatus
+from apps.exams.models import ExamDeployment, ExamSubmission
+from apps.exams.serializers.cheating_serializers import ExamCheatingResponseSerializer
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.exam_status_service import ensure_student_role, is_exam_closed
+from apps.users.models import User
+
+
+class ExamCheatingUpdateAPIView(APIView):
+    """부정행위 횟수를 증가시키고 종료 여부를 판단."""
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = ExamCheatingResponseSerializer
+
+    @extend_schema(
+        tags=["쪽지시험"],
+        summary="쪽지시험 부정행위 카운트 업데이트 API",
+        description="""
+        시험 응시 중 화면 이탈 등 부정행위가 발생했을 때 카운트를 증가시킵니다.
+        부정행위 3회 이상이면 force_submit=True로 종료 처리 응답을 반환합니다.
+        """,
+        parameters=[
+            OpenApiParameter(
+                name="deployment_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description="시험 배포 ID",
+            )
+        ],
+        responses={
+            200: ExamCheatingResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 시험 응시 세션"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+            410: OpenApiResponse(ErrorResponseSerializer, description="시험 종료"),
+        },
+    )
+    def post(self, request: Request, deployment_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            deployment_model = cast(Any, ExamDeployment)
+            deployment = deployment_model.objects.select_related("exam", "cohort").get(id=deployment_id)
+        except ExamDeployment.DoesNotExist:
+            error = ErrorResponseSerializer(data={"error_detail": "해당 시험 정보를 찾을 수 없습니다."})
+            error.is_valid(raise_exception=True)
+            return Response(error.data, status=404)
+
+        if not ensure_student_role(user):
+            error = ErrorResponseSerializer(data={"error_detail": "권한이 없습니다."})
+            error.is_valid(raise_exception=True)
+            return Response(error.data, status=403)
+
+        with transaction.atomic():
+            submission_model = cast(Any, ExamSubmission)
+            locked_submission = (
+                submission_model.objects.select_for_update()
+                .filter(submitter=user, deployment=deployment)
+                .order_by("-created_at")
+                .first()
+            )
+            if not locked_submission:
+                error = ErrorResponseSerializer(data={"error_detail": "유효하지 않은 시험 응시 세션입니다."})
+                error.is_valid(raise_exception=True)
+                return Response(error.data, status=400)
+
+            if is_exam_closed(deployment, locked_submission):
+                error = ErrorResponseSerializer(data={"error_detail": "시험이 이미 종료되었습니다."})
+                error.is_valid(raise_exception=True)
+                return Response(error.data, status=410)
+
+            locked_submission.cheating_count = F("cheating_count") + 1
+            locked_submission.save(update_fields=["cheating_count", "updated_at"])
+            locked_submission.refresh_from_db(fields=["cheating_count"])
+
+        is_closed = is_exam_closed(deployment, locked_submission)
+        serializer = self.serializer_class(
+            data={
+                "cheating_count": locked_submission.cheating_count,
+                "exam_status": (ExamStatus.CLOSED if is_closed else ExamStatus.ACTIVATED).value,
+                "force_submit": is_closed,
+            }
+        )
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data)

--- a/apps/exams/views/status_views.py
+++ b/apps/exams/views/status_views.py
@@ -1,0 +1,82 @@
+from typing import Any, cast
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.constants import ExamStatus
+from apps.exams.models import ExamDeployment
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.serializers.status_serializers import ExamStatusResponseSerializer
+from apps.exams.services.exam_status_service import (
+    ensure_student_role,
+    get_submission,
+    is_exam_closed,
+)
+from apps.users.models import User
+
+
+class ExamStatusCheckAPIView(APIView):
+    """수강생 응시 세션의 현재 시험 상태를 조회."""
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = ExamStatusResponseSerializer
+
+    @extend_schema(
+        tags=["쪽지시험"],
+        summary="쪽지시험 상태 확인 API",
+        description="""
+        수강생이 쪽지시험 응시 중인 상태를 확인합니다.
+        시험이 종료되었거나 비활성화된 경우 force_submit=True로 응답합니다.
+        """,
+        parameters=[
+            OpenApiParameter(
+                name="deployment_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description="시험 배포 ID",
+            )
+        ],
+        responses={
+            200: ExamStatusResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 시험 응시 세션"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+        },
+    )
+    def get(self, request: Request, deployment_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            deployment_model = cast(Any, ExamDeployment)
+            deployment = deployment_model.objects.select_related("exam", "cohort").get(id=deployment_id)
+        except ExamDeployment.DoesNotExist:
+            error = ErrorResponseSerializer(data={"error_detail": "해당 시험 정보를 찾을 수 없습니다."})
+            error.is_valid(raise_exception=True)
+            return Response(error.data, status=404)
+
+        if not ensure_student_role(user):
+            error = ErrorResponseSerializer(data={"error_detail": "권한이 없습니다."})
+            error.is_valid(raise_exception=True)
+            return Response(error.data, status=403)
+
+        submission = get_submission(user, deployment)
+        if not submission:
+            error = ErrorResponseSerializer(data={"error_detail": "유효하지 않은 시험 응시 세션입니다."})
+            error.is_valid(raise_exception=True)
+            return Response(error.data, status=400)
+
+        is_closed = is_exam_closed(deployment, submission)
+        serializer = self.serializer_class(
+            data={
+                "exam_status": (ExamStatus.CLOSED if is_closed else ExamStatus.ACTIVATED).value,
+                "force_submit": is_closed,
+            }
+        )
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data)

--- a/apps/exams/views/status_views.py
+++ b/apps/exams/views/status_views.py
@@ -1,5 +1,3 @@
-from typing import Any, cast
-
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework.permissions import IsAuthenticated
@@ -49,8 +47,7 @@ class ExamStatusCheckAPIView(APIView):
     )
     def get(self, request: Request, deployment_id: int) -> Response:
         try:
-            deployment_model = cast(Any, ExamDeployment)
-            deployment = deployment_model.objects.select_related("exam", "cohort").get(id=deployment_id)
+            deployment = ExamDeployment.objects.select_related("exam", "cohort").get(id=deployment_id)
         except ExamDeployment.DoesNotExist:
             return Response({"error_detail": "해당 시험 정보를 찾을 수 없습니다."}, status=404)
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
+    path("api/exams/", include("apps.exams.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/accounts/", include("apps.users.urls")),
     path("", include("apps.exams.urls")),


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 쪽지시험 응시 상태/부정행위 API 구현 및 테스트 추가

## 📄 상세 내용
- [x] `apps/exams/views/status_views.py`의 `ExamStatusCheckAPIView`에 상태 확인 API 구현
- [x] `apps/exams/views/cheating_views.py`의 `ExamCheatingUpdateAPIView`에 부정행위 카운트 API 구현
- [x] `apps/exams/services/exam_status_service.py`의 `is_exam_closed`, `get_submission` 로직 및 `apps/exams/constants.py`의 `ExamStatus` 상수 추가
- [x] `apps/exams/serializers/status_serializers.py`/`cheating_serializers.py`/`error_serializers.py` 응답 스키마 정의
- [x] `apps/exams/tests/test_status_views.py`, `apps/exams/tests/test_cheating_views.py` 테스트 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
