### PR TITLE
[feature/exam-apply] feat: 쪽지시험 응시 기능 구현

### DIFF
--- a/apps/exams/migrations/0002_alter_exam_thumbnail_img_url_and_more.py
+++ b/apps/exams/migrations/0002_alter_exam_thumbnail_img_url_and_more.py
@@ -30,7 +30,6 @@ class Migration(migrations.Migration):
             name="status",
             field=models.CharField(
                 choices=[("ACTIVATED", "시험 응시 가능"), ("DEACTIVATED", "시험 비활성화")],
-                db_default="ACTIVATED",
                 default="DEACTIVATED",
                 max_length=20,
                 verbose_name="상태",

--- a/apps/exams/models/exam_deployments.py
+++ b/apps/exams/models/exam_deployments.py
@@ -23,7 +23,6 @@ class ExamDeployment(TimeStampModel):
         choices=StatusChoices.choices,
         default=StatusChoices.DEACTIVATED,
         verbose_name="상태",
-        db_default="ACTIVATED",
     )
 
     def __str__(self) -> str:

--- a/apps/exams/serializers/__init__.py
+++ b/apps/exams/serializers/__init__.py
@@ -1,6 +1,6 @@
-from .take_exam import TakeExamRequestSerializer, TakeExamResponseSerializer
+from .take_exam import CheckCodeRequestSerializer, TakeExamResponseSerializer
 
 __all__ = [
-    "TakeExamRequestSerializer",
+    "CheckCodeRequestSerializer",
     "TakeExamResponseSerializer",
 ]

--- a/apps/exams/serializers/__init__.py
+++ b/apps/exams/serializers/__init__.py
@@ -1,0 +1,6 @@
+from .take_exam import TakeExamRequestSerializer, TakeExamResponseSerializer
+
+__all__ = [
+    "TakeExamRequestSerializer",
+    "TakeExamResponseSerializer",
+]

--- a/apps/exams/serializers/__init__.py
+++ b/apps/exams/serializers/__init__.py
@@ -1,6 +1,11 @@
-from .take_exam import CheckCodeRequestSerializer, TakeExamResponseSerializer
+from .take_exam import (
+    CheckCodeRequestSerializer,
+    TakeExamRequestSerializer,
+    TakeExamResponseSerializer,
+)
 
 __all__ = [
     "CheckCodeRequestSerializer",
+    "TakeExamRequestSerializer",
     "TakeExamResponseSerializer",
 ]

--- a/apps/exams/serializers/__init__.py
+++ b/apps/exams/serializers/__init__.py
@@ -1,3 +1,9 @@
+from .exam_status import ExamStatusResponseSerializer
+from .submit_exam import (
+    AnswerItemSerializer,
+    SubmitExamRequestSerializer,
+    SubmitExamResponseSerializer,
+)
 from .take_exam import (
     CheckCodeRequestSerializer,
     TakeExamRequestSerializer,
@@ -5,7 +11,11 @@ from .take_exam import (
 )
 
 __all__ = [
+    "AnswerItemSerializer",
     "CheckCodeRequestSerializer",
+    "ExamStatusResponseSerializer",
+    "SubmitExamRequestSerializer",
+    "SubmitExamResponseSerializer",
     "TakeExamRequestSerializer",
     "TakeExamResponseSerializer",
 ]

--- a/apps/exams/serializers/exam_status.py
+++ b/apps/exams/serializers/exam_status.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import serializers
+
+
+class ExamStatusResponseSerializer(serializers.Serializer[Any]):
+    exam_status = serializers.CharField(help_text="시험 상태 (in_progress, closed)")
+    force_submit = serializers.BooleanField(help_text="강제 제출 여부")

--- a/apps/exams/serializers/submit_exam.py
+++ b/apps/exams/serializers/submit_exam.py
@@ -16,3 +16,10 @@ class SubmitExamRequestSerializer(serializers.Serializer[Any]):
     deployment_id = serializers.IntegerField(required=True)
     started_at = serializers.DateTimeField(required=False, allow_null=True)
     answers = AnswerItemSerializer(many=True, required=True)
+
+
+class SubmitExamResponseSerializer(serializers.Serializer[Any]):
+    submission_id = serializers.IntegerField(help_text="제출 ID")
+    correct_answer_count = serializers.IntegerField(help_text="정답 개수")
+    score = serializers.IntegerField(help_text="획득 점수")
+    redirect_url = serializers.CharField(help_text="결과 페이지 URL")

--- a/apps/exams/serializers/submit_exam.py
+++ b/apps/exams/serializers/submit_exam.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+from typing import Any
+
 from rest_framework import serializers
 
 
-class AnswerItemSerializer(serializers.Serializer):
+class AnswerItemSerializer(serializers.Serializer[Any]):
     question_id = serializers.IntegerField(required=True)
     type = serializers.CharField(required=False, allow_blank=True)
     submitted_answer = serializers.JSONField(required=False, allow_null=True)
     answer_input = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
 
-class SubmitExamRequestSerializer(serializers.Serializer):
+class SubmitExamRequestSerializer(serializers.Serializer[Any]):
     deployment_id = serializers.IntegerField(required=True)
     started_at = serializers.DateTimeField(required=False, allow_null=True)
     answers = AnswerItemSerializer(many=True, required=True)

--- a/apps/exams/serializers/submit_exam.py
+++ b/apps/exams/serializers/submit_exam.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class AnswerItemSerializer(serializers.Serializer):
+    question_id = serializers.IntegerField(required=True)
+    type = serializers.CharField(required=False, allow_blank=True)
+    submitted_answer = serializers.JSONField(required=False, allow_null=True)
+    answer_input = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
+
+class SubmitExamRequestSerializer(serializers.Serializer):
+    deployment_id = serializers.IntegerField(required=True)
+    started_at = serializers.DateTimeField(required=False, allow_null=True)
+    answers = AnswerItemSerializer(many=True, required=True)

--- a/apps/exams/serializers/take_exam.py
+++ b/apps/exams/serializers/take_exam.py
@@ -11,6 +11,15 @@ class CheckCodeRequestSerializer(serializers.Serializer):
     )
 
 
+class TakeExamRequestSerializer(serializers.Serializer):
+    access_code = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        max_length=64,
+        help_text="참가코드(Base62 인코딩된 값)",
+    )
+
+
 class QuestionSerializer(serializers.Serializer):
     question_id = serializers.IntegerField()
     number = serializers.IntegerField()

--- a/apps/exams/serializers/take_exam.py
+++ b/apps/exams/serializers/take_exam.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from rest_framework import serializers
 
 
-class TakeExamRequestSerializer(serializers.Serializer):
+class TakeExamRequestSerializer(serializers.Serializer[dict[str, str]]):
     access_code = serializers.CharField(
         required=True,
         allow_blank=False,
@@ -12,7 +12,7 @@ class TakeExamRequestSerializer(serializers.Serializer):
     )
 
 
-class TakeExamResponseSerializer(serializers.Serializer):
+class TakeExamResponseSerializer(serializers.Serializer[dict[str, int | str]]):
     submission_id = serializers.IntegerField()
     started_at = serializers.DateTimeField()
 

--- a/apps/exams/serializers/take_exam.py
+++ b/apps/exams/serializers/take_exam.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class TakeExamRequestSerializer(serializers.Serializer):
+    access_code = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        max_length=64,
+        help_text="참가코드(Base62 인코딩된 값)",
+    )
+
+
+class TakeExamResponseSerializer(serializers.Serializer):
+    submission_id = serializers.IntegerField()
+    started_at = serializers.DateTimeField()
+
+    deployment_id = serializers.IntegerField()
+    duration_time = serializers.IntegerField()
+    open_at = serializers.DateTimeField()
+    close_at = serializers.DateTimeField()
+    questions_snapshot_json = serializers.JSONField()
+
+    exam_id = serializers.IntegerField()
+    exam_title = serializers.CharField()
+    exam_thumbnail_img_url = serializers.CharField()
+    subject_id = serializers.IntegerField()

--- a/apps/exams/serializers/take_exam.py
+++ b/apps/exams/serializers/take_exam.py
@@ -3,26 +3,30 @@ from __future__ import annotations
 from rest_framework import serializers
 
 
-class TakeExamRequestSerializer(serializers.Serializer[dict[str, str]]):
-    access_code = serializers.CharField(
+class CheckCodeRequestSerializer(serializers.Serializer):
+    code = serializers.CharField(
         required=True,
         allow_blank=False,
-        max_length=64,
         help_text="참가코드(Base62 인코딩된 값)",
     )
 
 
-class TakeExamResponseSerializer(serializers.Serializer[dict[str, int | str]]):
-    submission_id = serializers.IntegerField()
-    started_at = serializers.DateTimeField()
+class QuestionSerializer(serializers.Serializer):
+    question_id = serializers.IntegerField()
+    number = serializers.IntegerField()
+    type = serializers.CharField()
+    question = serializers.CharField()
+    point = serializers.IntegerField()
+    prompt = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    blank_count = serializers.IntegerField(allow_null=True, required=False)
+    options = serializers.ListField(child=serializers.CharField(), allow_null=True, required=False)
+    answer_input = serializers.CharField(allow_null=True, required=False)
 
-    deployment_id = serializers.IntegerField()
-    duration_time = serializers.IntegerField()
-    open_at = serializers.DateTimeField()
-    close_at = serializers.DateTimeField()
-    questions_snapshot_json = serializers.JSONField()
 
+class TakeExamResponseSerializer(serializers.Serializer):
     exam_id = serializers.IntegerField()
-    exam_title = serializers.CharField()
-    exam_thumbnail_img_url = serializers.CharField()
-    subject_id = serializers.IntegerField()
+    exam_name = serializers.CharField()
+    duration_time = serializers.IntegerField()
+    elapsed_time = serializers.IntegerField()
+    cheating_count = serializers.IntegerField()
+    questions = QuestionSerializer(many=True)

--- a/apps/exams/serializers/take_exam.py
+++ b/apps/exams/serializers/take_exam.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 from rest_framework import serializers
 
 
-class CheckCodeRequestSerializer(serializers.Serializer):
+class CheckCodeRequestSerializer(serializers.Serializer[Any]):
     code = serializers.CharField(
         required=True,
         allow_blank=False,
@@ -11,7 +13,7 @@ class CheckCodeRequestSerializer(serializers.Serializer):
     )
 
 
-class TakeExamRequestSerializer(serializers.Serializer):
+class TakeExamRequestSerializer(serializers.Serializer[Any]):
     access_code = serializers.CharField(
         required=True,
         allow_blank=False,
@@ -20,7 +22,7 @@ class TakeExamRequestSerializer(serializers.Serializer):
     )
 
 
-class QuestionSerializer(serializers.Serializer):
+class QuestionSerializer(serializers.Serializer[Any]):
     question_id = serializers.IntegerField()
     number = serializers.IntegerField()
     type = serializers.CharField()
@@ -32,7 +34,7 @@ class QuestionSerializer(serializers.Serializer):
     answer_input = serializers.CharField(allow_null=True, required=False)
 
 
-class TakeExamResponseSerializer(serializers.Serializer):
+class TakeExamResponseSerializer(serializers.Serializer[Any]):
     exam_id = serializers.IntegerField()
     exam_name = serializers.CharField()
     duration_time = serializers.IntegerField()

--- a/apps/exams/services/__init__.py
+++ b/apps/exams/services/__init__.py
@@ -1,6 +1,8 @@
+from .submit_exam import submit_exam
 from .take_exam import build_take_exam_response, take_exam
 
 __all__ = [
-    "take_exam",
     "build_take_exam_response",
+    "submit_exam",
+    "take_exam",
 ]

--- a/apps/exams/services/__init__.py
+++ b/apps/exams/services/__init__.py
@@ -1,0 +1,6 @@
+from .take_exam import build_take_exam_response, take_exam
+
+__all__ = [
+    "take_exam",
+    "build_take_exam_response",
+]

--- a/apps/exams/services/submit_exam.py
+++ b/apps/exams/services/submit_exam.py
@@ -26,14 +26,95 @@ def _grade_answers(
             continue
         point = int(q.get("point") or 0)
         ans = q.get("answer")
+        q_type = q.get("type", "")
         sub = by_id[qid]
         val = sub.get("submitted_answer") or sub.get("answer_input") or ""
         if ans is None:
             continue
-        if isinstance(ans, list):
-            ok = val in ans or (isinstance(val, list) and set(val) == set(ans))
+
+        # 타입별 채점 로직
+        ok = False
+
+        # OX 문제
+        if q_type == "OX":
+            ok = str(val).strip().upper() == str(ans).strip().upper()
+
+        # 주관식 단답형
+        elif q_type == "SHORT_ANSWER":
+            ok = str(val).strip().lower() == str(ans).strip().lower()
+
+        # 다지선다 (MULTI_SELECT)
+        elif q_type == "MULTI_SELECT":
+            # 정답이 리스트인 경우
+            if isinstance(ans, list):
+                # 제출 답안도 리스트로 변환
+                if isinstance(val, (str, int)):
+                    val = [val]
+                if isinstance(val, list):
+                    # 집합으로 변환하여 순서 무관 비교
+                    ok = set(val) == set(ans)
+                else:
+                    ok = False
+            # 정답이 단일 값인 경우
+            else:
+                # 제출 답안이 리스트인 경우
+                if isinstance(val, list):
+                    ok = ans in val
+                # 제출 답안이 단일 값인 경우
+                else:
+                    ok = str(val).strip() == str(ans).strip()
+
+        # 순서 정렬 (ORDERING)
+        elif q_type == "ORDERING":
+            if isinstance(ans, list):
+                if isinstance(val, list):
+                    # 순서가 중요하므로 리스트 비교
+                    ok = list(val) == list(ans)
+                else:
+                    ok = False
+            else:
+                # 정답이 단일 값인 경우 리스트로 변환
+                if isinstance(val, list):
+                    ok = len(val) == 1 and val[0] == ans
+                else:
+                    ok = str(val).strip() == str(ans).strip()
+
+        # 빈칸 채우기 (FILL_IN_BLANK)
+        elif q_type == "FILL_IN_BLANK":
+            # 정답이 리스트인 경우
+            if isinstance(ans, list):
+                if isinstance(val, list):
+                    # 각 빈칸을 순서대로 비교
+                    if len(val) == len(ans):
+                        ok = all(str(v).strip().lower() == str(a).strip().lower() for v, a in zip(val, ans))
+                    else:
+                        ok = False
+                else:
+                    # 제출 답안이 단일 값인 경우, 정답이 1개인 경우만 비교
+                    ok = len(ans) == 1 and str(val).strip().lower() == str(ans[0]).strip().lower()
+            # 정답이 단일 값인 경우
+            else:
+                if isinstance(val, list):
+                    # 제출 답안이 리스트인 경우, 정답이 1개인 경우만 비교
+                    ok = len(val) == 1 and str(val[0]).strip().lower() == str(ans).strip().lower()
+                else:
+                    ok = str(val).strip().lower() == str(ans).strip().lower()
+
+        # 기본값: 단순 문자열 비교
         else:
-            ok = str(val).strip() == str(ans).strip()
+            if isinstance(ans, list):
+                # 정답이 리스트인 경우
+                if isinstance(val, list):
+                    ok = set(val) == set(ans)
+                else:
+                    ok = val in ans
+            else:
+                # 정답이 단일 값인 경우
+                if isinstance(val, list):
+                    ok = ans in val
+                else:
+                    ok = str(val).strip() == str(ans).strip()
+
         if ok:
             correct += 1
             score_earned += point
@@ -66,6 +147,10 @@ def submit_exam(
 
     if not submission:
         raise ValidationError({"error_detail": "유효하지 않은 시험 응시 세션입니다."})
+
+    # 이미 제출된 시험 체크
+    if submission.answers_json is not None and len(submission.answers_json) > 0:
+        raise ValidationError({"error_detail": "이미 제출된 시험입니다."})
 
     answers_json = [a for a in answers]
     snapshot = deployment.questions_snapshot_json

--- a/apps/exams/services/submit_exam.py
+++ b/apps/exams/services/submit_exam.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from apps.exams.models import ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+
+def _grade_answers(
+    snapshot: list[dict],
+    answers: list[dict],
+) -> tuple[int, int]:
+    """채점 후 (correct_count, score_earned) 반환."""
+    by_id = {int(a["question_id"]): a for a in answers if "question_id" in a}
+    correct = 0
+    score_earned = 0
+    for q in snapshot or []:
+        qid = q.get("id")
+        if qid is None:
+            continue
+        qid = int(qid) if isinstance(qid, (int, float)) else None
+        if qid is None or qid not in by_id:
+            continue
+        point = int(q.get("point") or 0)
+        ans = q.get("answer")
+        sub = by_id[qid]
+        val = sub.get("submitted_answer") or sub.get("answer_input") or ""
+        if ans is None:
+            continue
+        if isinstance(ans, list):
+            ok = val in ans or (isinstance(val, list) and set(val) == set(ans))
+        else:
+            ok = str(val).strip() == str(ans).strip()
+        if ok:
+            correct += 1
+            score_earned += point
+    return correct, score_earned
+
+
+def submit_exam(
+    *,
+    user: User,
+    deployment_id: int,
+    started_at: str | None,
+    answers: list[dict],
+) -> ExamSubmission:
+    if user.role != User.Role.STUDENT:
+        raise ValidationError({"detail": "수강생 권한이 필요합니다."})
+
+    try:
+        deployment = ExamDeployment.objects.get(id=deployment_id)
+    except ExamDeployment.DoesNotExist as exc:
+        raise ValidationError({"detail": "해당 시험 정보를 찾을 수 없습니다."}) from exc
+
+    now = timezone.now()
+    if now > deployment.close_at:
+        raise ValidationError({"detail": "시험이 이미 종료되었습니다."})
+
+    submission = ExamSubmission.objects.filter(
+        submitter=user,
+        deployment=deployment,
+    ).first()
+
+    if not submission:
+        raise ValidationError({"error_detail": "유효하지 않은 시험 응시 세션입니다."})
+
+    answers_json = [a for a in answers]
+    snapshot = deployment.questions_snapshot_json
+    if not isinstance(snapshot, list):
+        snapshot = []
+    correct_count, score_earned = _grade_answers(snapshot, answers_json)
+
+    submission.answers_json = answers_json
+    submission.score = score_earned
+    submission.correct_answer_count = correct_count
+    submission.save(update_fields=["answers_json", "score", "correct_answer_count", "updated_at"])
+
+    return submission

--- a/apps/exams/services/submit_exam.py
+++ b/apps/exams/services/submit_exam.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
@@ -8,8 +10,8 @@ from apps.users.models import User
 
 
 def _grade_answers(
-    snapshot: list[dict],
-    answers: list[dict],
+    snapshot: list[dict[str, Any]],
+    answers: list[dict[str, Any]],
 ) -> tuple[int, int]:
     """채점 후 (correct_count, score_earned) 반환."""
     by_id = {int(a["question_id"]): a for a in answers if "question_id" in a}
@@ -43,7 +45,7 @@ def submit_exam(
     user: User,
     deployment_id: int,
     started_at: str | None,
-    answers: list[dict],
+    answers: list[dict[str, Any]],
 ) -> ExamSubmission:
     if user.role != User.Role.STUDENT:
         raise ValidationError({"detail": "수강생 권한이 필요합니다."})

--- a/apps/exams/services/take_exam.py
+++ b/apps/exams/services/take_exam.py
@@ -45,8 +45,8 @@ def take_exam(*, user: User, access_code: str) -> TakeExamResult:
     )
 
     # answers_json은 JSONField(null=False)라 빈 dict로라도 보장
-    if submission.answers_json is None:  # type: ignore[truthy-bool]
-        submission.answers_json = {}  # type: ignore[assignment]
+    if not submission.answers_json:
+        submission.answers_json = {}
         submission.save(update_fields=["answers_json"])
 
     return TakeExamResult(submission=submission, deployment=deployment)

--- a/apps/exams/services/take_exam.py
+++ b/apps/exams/services/take_exam.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from apps.exams.models import ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+
+@dataclass(frozen=True)
+class TakeExamResult:
+    submission: ExamSubmission
+    deployment: ExamDeployment
+
+
+def take_exam(*, user: User, access_code: str) -> TakeExamResult:
+    if user.role != User.Role.STUDENT:
+        raise ValidationError({"detail": "수강생 권한이 필요합니다."})
+
+    try:
+        deployment = ExamDeployment.objects.select_related("exam", "exam__subject").get(access_code=access_code)
+    except ExamDeployment.DoesNotExist as exc:
+        raise ValidationError({"detail": "참가 코드가 올바르지 않습니다."}) from exc
+
+    if deployment.status != ExamDeployment.StatusChoices.ACTIVATED:
+        raise ValidationError({"detail": "현재 응시할 수 없는 시험입니다."})
+
+    now = timezone.now()
+    if now < deployment.open_at or now > deployment.close_at:
+        raise ValidationError({"detail": "응시 가능 시간이 아닙니다."})
+
+    submission, _created = ExamSubmission.objects.get_or_create(
+        submitter=user,
+        deployment=deployment,
+        defaults={
+            "started_at": now,
+            "cheating_count": 0,
+            "answers_json": {},
+            "score": 0,
+            "correct_answer_count": 0,
+        },
+    )
+
+    # answers_json은 JSONField(null=False)라 빈 dict로라도 보장
+    if submission.answers_json is None:  # type: ignore[truthy-bool]
+        submission.answers_json = {}  # type: ignore[assignment]
+        submission.save(update_fields=["answers_json"])
+
+    return TakeExamResult(submission=submission, deployment=deployment)
+
+
+def build_take_exam_response(*, result: TakeExamResult) -> dict[str, Any]:
+    deployment = result.deployment
+    exam = deployment.exam
+    subject = exam.subject
+
+    return {
+        "submission_id": result.submission.id,
+        "started_at": result.submission.started_at,
+        "deployment_id": deployment.id,
+        "duration_time": deployment.duration_time,
+        "open_at": deployment.open_at,
+        "close_at": deployment.close_at,
+        "questions_snapshot_json": deployment.questions_snapshot_json,
+        "exam_id": exam.id,
+        "exam_title": exam.title,
+        "exam_thumbnail_img_url": exam.thumbnail_img_url,
+        "subject_id": subject.id,
+    }

--- a/apps/exams/services/take_exam.py
+++ b/apps/exams/services/take_exam.py
@@ -6,7 +6,6 @@ from typing import Any
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
-from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamDeployment, ExamSubmission
 from apps.users.models import User
 
@@ -102,21 +101,3 @@ def build_take_exam_response(*, result: TakeExamResult) -> dict[str, Any]:
         "cheating_count": submission.cheating_count,
         "questions": questions,
     }
-
-
-def check_code(*, user: User, deployment_id: int, code: str) -> None:
-    """참가코드 검증"""
-    if user.role != User.Role.STUDENT:
-        raise ErrorDetailException("시험에 응시할 권한이 없습니다.", 403)
-
-    try:
-        deployment = ExamDeployment.objects.get(id=deployment_id)
-    except ExamDeployment.DoesNotExist:
-        raise ErrorDetailException("배포 정보를 찾을 수 없습니다.", 404)
-
-    if deployment.access_code != code:
-        raise ErrorDetailException("응시 코드가 일치하지 않습니다.", 400)
-
-    now = timezone.now()
-    if now < deployment.open_at:
-        raise ErrorDetailException("아직 응시할 수 없습니다.", 423)

--- a/apps/exams/services/take_exam.py
+++ b/apps/exams/services/take_exam.py
@@ -16,21 +16,23 @@ class TakeExamResult:
     deployment: ExamDeployment
 
 
-def take_exam(*, user: User, access_code: str) -> TakeExamResult:
+def take_exam(*, user: User, deployment_id: int) -> TakeExamResult:
     if user.role != User.Role.STUDENT:
         raise ValidationError({"detail": "수강생 권한이 필요합니다."})
 
     try:
-        deployment = ExamDeployment.objects.select_related("exam", "exam__subject").get(access_code=access_code)
+        deployment = ExamDeployment.objects.select_related("exam", "exam__subject").get(id=deployment_id)
     except ExamDeployment.DoesNotExist as exc:
-        raise ValidationError({"detail": "참가 코드가 올바르지 않습니다."}) from exc
+        raise ValidationError({"detail": "해당 시험 정보를 찾을 수 없습니다."}) from exc
 
     if deployment.status != ExamDeployment.StatusChoices.ACTIVATED:
         raise ValidationError({"detail": "현재 응시할 수 없는 시험입니다."})
 
     now = timezone.now()
-    if now < deployment.open_at or now > deployment.close_at:
-        raise ValidationError({"detail": "응시 가능 시간이 아닙니다."})
+    if now < deployment.open_at:
+        raise ValidationError({"detail": "아직 응시할 수 없습니다."})
+    if now > deployment.close_at:
+        raise ValidationError({"detail": "시험이 종료되었습니다."})
 
     submission, _created = ExamSubmission.objects.get_or_create(
         submitter=user,
@@ -53,20 +55,49 @@ def take_exam(*, user: User, access_code: str) -> TakeExamResult:
 
 
 def build_take_exam_response(*, result: TakeExamResult) -> dict[str, Any]:
+    from django.utils import timezone
+
     deployment = result.deployment
     exam = deployment.exam
-    subject = exam.subject
+    submission = result.submission
+
+    # elapsed_time 계산 (초 단위)
+    now = timezone.now()
+    elapsed_seconds = int((now - submission.started_at).total_seconds())
+    elapsed_time = max(0, elapsed_seconds)
+
+    # questions_snapshot_json을 명세서 형식에 맞게 변환
+    questions = []
+    if deployment.questions_snapshot_json:
+        for idx, question_data in enumerate(deployment.questions_snapshot_json, start=1):
+            # 타입 매핑 (모델 타입 -> 명세서 타입)
+            type_mapping = {
+                "MULTI_SELECT": "multiple_choice",
+                "FILL_IN_BLANK": "fill_blank",
+                "ORDERING": "ordering",
+                "SHORT_ANSWER": "short_answer",
+                "OX": "ox",
+            }
+            question_type = type_mapping.get(question_data.get("type", ""), question_data.get("type", "").lower())
+
+            question = {
+                "question_id": question_data.get("id"),
+                "number": idx,
+                "type": question_type,
+                "question": question_data.get("question", ""),
+                "point": question_data.get("point", 0),
+                "prompt": question_data.get("prompt"),
+                "blank_count": question_data.get("blank_count") if question_type == "fill_blank" else None,
+                "options": question_data.get("options") if question_type in ["multiple_choice", "ordering"] else None,
+                "answer_input": None,  # 응시자가 입력할 답안 필드 (초기값은 None)
+            }
+            questions.append(question)
 
     return {
-        "submission_id": result.submission.id,
-        "started_at": result.submission.started_at,
-        "deployment_id": deployment.id,
-        "duration_time": deployment.duration_time,
-        "open_at": deployment.open_at,
-        "close_at": deployment.close_at,
-        "questions_snapshot_json": deployment.questions_snapshot_json,
         "exam_id": exam.id,
-        "exam_title": exam.title,
-        "exam_thumbnail_img_url": exam.thumbnail_img_url,
-        "subject_id": subject.id,
+        "exam_name": exam.title,
+        "duration_time": deployment.duration_time,
+        "elapsed_time": elapsed_time,
+        "cheating_count": submission.cheating_count,
+        "questions": questions,
     }

--- a/apps/exams/services/take_exam.py
+++ b/apps/exams/services/take_exam.py
@@ -6,6 +6,7 @@ from typing import Any
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamDeployment, ExamSubmission
 from apps.users.models import User
 
@@ -101,3 +102,21 @@ def build_take_exam_response(*, result: TakeExamResult) -> dict[str, Any]:
         "cheating_count": submission.cheating_count,
         "questions": questions,
     }
+
+
+def check_code(*, user: User, deployment_id: int, code: str) -> None:
+    """참가코드 검증"""
+    if user.role != User.Role.STUDENT:
+        raise ErrorDetailException("시험에 응시할 권한이 없습니다.", 403)
+
+    try:
+        deployment = ExamDeployment.objects.get(id=deployment_id)
+    except ExamDeployment.DoesNotExist:
+        raise ErrorDetailException("배포 정보를 찾을 수 없습니다.", 404)
+
+    if deployment.access_code != code:
+        raise ErrorDetailException("응시 코드가 일치하지 않습니다.", 400)
+
+    now = timezone.now()
+    if now < deployment.open_at:
+        raise ErrorDetailException("아직 응시할 수 없습니다.", 423)

--- a/apps/exams/tests/test_cheating_views.py
+++ b/apps/exams/tests/test_cheating_views.py
@@ -159,7 +159,7 @@ class ExamCheatingUpdateAPITest(TestCase):
 
     def test_cheating_requires_authentication(self) -> None:
         self._clear_cache()
-        response = self.client.post(f"/api/exams/deployments/{self.deployment.id}/cheating/")
+        response = self.client.post(f"/api/v1/exams/deployments/{self.deployment.id}/cheating/")
 
         self.assertEqual(response.status_code, 401)
         data = response.json()

--- a/apps/exams/tests/test_cheating_views.py
+++ b/apps/exams/tests/test_cheating_views.py
@@ -85,7 +85,7 @@ class ExamCheatingUpdateAPITest(TestCase):
     def test_cheating_increments_count(self) -> None:
         self._clear_cache()
         response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.student),
         )
 
@@ -99,12 +99,12 @@ class ExamCheatingUpdateAPITest(TestCase):
         self._clear_cache()
         for _ in range(2):
             self.client.post(
-                f"/api/exams/deployments/{self.deployment.id}/cheating/",
+                f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
                 headers=self._auth_headers(self.student),
             )
 
         response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.student),
         )
 
@@ -117,7 +117,7 @@ class ExamCheatingUpdateAPITest(TestCase):
         cache.set(self._cache_key(), 3, timeout=60)
 
         response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
             data={"answers_json": []},
             content_type="application/json",
             headers=self._auth_headers(self.student),
@@ -138,7 +138,7 @@ class ExamCheatingUpdateAPITest(TestCase):
         )
 
         response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.student),
         )
 
@@ -149,7 +149,7 @@ class ExamCheatingUpdateAPITest(TestCase):
     def test_cheating_returns_403_for_non_student(self) -> None:
         self._clear_cache()
         response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.other_user),
         )
 
@@ -168,7 +168,7 @@ class ExamCheatingUpdateAPITest(TestCase):
     def test_cheating_returns_404_when_deployment_missing(self) -> None:
         self._clear_cache()
         response = self.client.post(
-            "/api/exams/deployments/9999/cheating/",
+            "/api/v1/exams/deployments/9999/cheating/",
             headers=self._auth_headers(self.student),
         )
 
@@ -182,7 +182,7 @@ class ExamCheatingUpdateAPITest(TestCase):
         self.deployment.save(update_fields=["status"])
 
         response = self.client.post(
-            f"/api/exams/deployments/{self.deployment.id}/cheating/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/cheating/",
             headers=self._auth_headers(self.student),
         )
 

--- a/apps/exams/tests/test_check_code.py
+++ b/apps/exams/tests/test_check_code.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.courses.models import Cohort, Course, Subject
+from apps.exams.models import Exam, ExamDeployment
+from apps.users.models import User
+
+
+class CheckCodeAPITest(APITestCase):
+    def setUp(self) -> None:
+        self.student_user = User.objects.create_user(
+            email="student@test.com",
+            password="testpass123",
+            name="테스트 학생",
+            nickname="학생",
+            phone_number="010-1234-5678",
+            gender=User.Gender.MALE,
+            birthday="2000-01-01",
+            role=User.Role.STUDENT,
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@test.com",
+            password="testpass123",
+            name="테스트 관리자",
+            nickname="관리자",
+            phone_number="010-8765-4321",
+            gender=User.Gender.MALE,
+            birthday="1990-01-01",
+            role=User.Role.ADMIN,
+        )
+        self.course = Course.objects.create(name="테스트 강좌")
+        self.subject = Subject.objects.create(
+            course=self.course, title="테스트 과목", number_of_days=30, number_of_hours=120
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=100,
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+        )
+        self.exam = Exam.objects.create(
+            title="테스트 시험",
+            thumbnail_img_url="https://example.com/thumb.jpg",
+            subject=self.subject,
+        )
+        now = timezone.now()
+        self.deployment = ExamDeployment.objects.create(
+            exam=self.exam,
+            cohort=self.cohort,
+            duration_time=60,
+            access_code="testcode123",
+            open_at=now - timedelta(hours=1),
+            close_at=now + timedelta(hours=1),
+            questions_snapshot_json=[],
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+
+    def _check_code_url(self) -> str:
+        return reverse("exams:check-code", kwargs={"deployment_id": self.deployment.id})
+
+    def test_check_code_success(self) -> None:
+        """참가코드 검증 성공 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self._check_code_url(), {"code": "testcode123"})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_check_code_invalid_code(self) -> None:
+        """잘못된 참가코드 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self._check_code_url(), {"code": "wrongcode"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+        self.assertIn("응시 코드가 일치하지 않습니다", str(response.data["error_detail"]))
+
+    def test_check_code_missing_code(self) -> None:
+        """참가코드 필드 누락 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self._check_code_url(), {})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_check_code_unauthenticated(self) -> None:
+        """인증되지 않은 사용자 테스트"""
+        response = self.client.post(self._check_code_url(), {"code": "testcode123"})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_check_code_non_student_role(self) -> None:
+        """수강생이 아닌 사용자 테스트"""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(self._check_code_url(), {"code": "testcode123"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("error_detail", response.data)
+        self.assertIn("시험에 응시할 권한이 없습니다", str(response.data["error_detail"]))
+
+    def test_check_code_deployment_not_found(self) -> None:
+        """존재하지 않는 배포 정보 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        url = reverse("exams:check-code", kwargs={"deployment_id": 99999})
+        response = self.client.post(url, {"code": "testcode123"})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("error_detail", response.data)
+        self.assertIn("해당 시험 정보를 찾을 수 없습니다", str(response.data["error_detail"]))
+
+    def test_check_code_deactivated_status(self) -> None:
+        """비활성화된 시험 테스트"""
+        self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
+        self.deployment.save()
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self._check_code_url(), {"code": "testcode123"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+        self.assertIn("현재 응시할 수 없는 시험입니다", str(response.data["error_detail"]))
+
+    def test_check_code_before_open_time(self) -> None:
+        """응시 시작 시간 전 테스트"""
+        now = timezone.now()
+        self.deployment.open_at = now + timedelta(hours=1)
+        self.deployment.close_at = now + timedelta(hours=2)
+        self.deployment.save()
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self._check_code_url(), {"code": "testcode123"})
+        self.assertEqual(response.status_code, status.HTTP_423_LOCKED)
+        self.assertIn("error_detail", response.data)
+        self.assertIn("아직 응시할 수 없습니다", str(response.data["error_detail"]))

--- a/apps/exams/tests/test_status_views.py
+++ b/apps/exams/tests/test_status_views.py
@@ -77,7 +77,7 @@ class ExamStatusCheckAPITest(TestCase):
 
     def test_status_returns_activated(self) -> None:
         response = self.client.get(
-            f"/api/exams/deployments/{self.deployment.id}/status/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/status/",
             headers=self._auth_headers(self.student),
         )
 
@@ -91,7 +91,7 @@ class ExamStatusCheckAPITest(TestCase):
         self.deployment.save(update_fields=["status"])
 
         response = self.client.get(
-            f"/api/exams/deployments/{self.deployment.id}/status/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/status/",
             headers=self._auth_headers(self.student),
         )
 
@@ -102,7 +102,7 @@ class ExamStatusCheckAPITest(TestCase):
 
     def test_status_returns_403_for_non_student(self) -> None:
         response = self.client.get(
-            f"/api/exams/deployments/{self.deployment.id}/status/",
+            f"/api/v1/exams/deployments/{self.deployment.id}/status/",
             headers=self._auth_headers(self.other_user),
         )
 
@@ -111,7 +111,7 @@ class ExamStatusCheckAPITest(TestCase):
         self.assertEqual(data["detail"], "권한이 없습니다.")
 
     def test_status_requires_authentication(self) -> None:
-        response = self.client.get(f"/api/exams/deployments/{self.deployment.id}/status/")
+        response = self.client.get(f"/api/v1/exams/deployments/{self.deployment.id}/status/")
 
         self.assertEqual(response.status_code, 401)
         data = response.json()
@@ -119,7 +119,7 @@ class ExamStatusCheckAPITest(TestCase):
 
     def test_status_returns_404_when_deployment_missing(self) -> None:
         response = self.client.get(
-            "/api/exams/deployments/9999/status/",
+            "/api/v1/exams/deployments/9999/status/",
             headers=self._auth_headers(self.student),
         )
 

--- a/apps/exams/tests/test_take_exam.py
+++ b/apps/exams/tests/test_take_exam.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.courses.models import Cohort, Course, Subject
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+
+class TakeExamAPITest(APITestCase):
+    def setUp(self) -> None:
+        """테스트 데이터 설정"""
+        self.take_exam_url = reverse("exams:take-exam")
+
+        self.student_user = User.objects.create_user(
+            email="student@test.com",
+            password="testpass123",
+            name="테스트 학생",
+            nickname="학생",
+            phone_number="010-1234-5678",
+            gender=User.Gender.MALE,
+            birthday="2000-01-01",
+            role=User.Role.STUDENT,
+        )
+
+        self.admin_user = User.objects.create_user(
+            email="admin@test.com",
+            password="testpass123",
+            name="테스트 관리자",
+            nickname="관리자",
+            phone_number="010-8765-4321",
+            gender=User.Gender.MALE,
+            birthday="1990-01-01",
+            role=User.Role.ADMIN,
+        )
+
+        # Course, Subject, Cohort 생성
+        self.course = Course.objects.create(name="테스트 강좌")
+        self.subject = Subject.objects.create(course=self.course, name="테스트 과목")
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=100,
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+        )
+
+        # Exam 생성
+        self.exam = Exam.objects.create(
+            title="테스트 시험",
+            thumbnail_img_url="https://example.com/thumb.jpg",
+            subject=self.subject,
+        )
+
+        # ExamDeployment 생성 (활성화, 응시 가능 시간 내)
+        now = timezone.now()
+        self.deployment = ExamDeployment.objects.create(
+            exam=self.exam,
+            cohort=self.cohort,
+            duration_time=60,
+            access_code="testcode123",
+            open_at=now - timedelta(hours=1),
+            close_at=now + timedelta(hours=1),
+            questions_snapshot_json={"questions": []},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+
+    def test_take_exam_success(self) -> None:
+        """응시 성공 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("submission_id", response.data)
+        self.assertIn("deployment_id", response.data)
+        self.assertIn("exam_id", response.data)
+        self.assertEqual(response.data["exam_id"], self.exam.id)
+        self.assertEqual(response.data["deployment_id"], self.deployment.id)
+
+        # DB에 submission이 생성되었는지 확인
+        submission = ExamSubmission.objects.get(submitter=self.student_user, deployment=self.deployment)
+        self.assertEqual(submission.deployment, self.deployment)
+
+    def test_take_exam_invalid_access_code(self) -> None:
+        """잘못된 참가코드 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self.take_exam_url, {"access_code": "invalid_code"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("참가 코드가 올바르지 않습니다", str(response.data["detail"]))
+
+    def test_take_exam_missing_access_code(self) -> None:
+        """참가코드 필드 누락 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self.take_exam_url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("access_code", response.data)
+
+    def test_take_exam_non_student_role(self) -> None:
+        """수강생이 아닌 사용자 테스트"""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("수강생 권한이 필요합니다", str(response.data["detail"]))
+
+    def test_take_exam_unauthenticated(self) -> None:
+        """인증되지 않은 사용자 테스트"""
+        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_take_exam_deactivated_status(self) -> None:
+        """비활성화된 시험 테스트"""
+        self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
+        self.deployment.save()
+
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("현재 응시할 수 없는 시험입니다", str(response.data["detail"]))
+
+    def test_take_exam_before_open_time(self) -> None:
+        """응시 시작 시간 전 테스트"""
+        now = timezone.now()
+        self.deployment.open_at = now + timedelta(hours=1)
+        self.deployment.close_at = now + timedelta(hours=2)
+        self.deployment.save()
+
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("응시 가능 시간이 아닙니다", str(response.data["detail"]))
+
+    def test_take_exam_after_close_time(self) -> None:
+        """응시 종료 시간 후 테스트"""
+        now = timezone.now()
+        self.deployment.open_at = now - timedelta(hours=2)
+        self.deployment.close_at = now - timedelta(hours=1)
+        self.deployment.save()
+
+        self.client.force_authenticate(user=self.student_user)
+        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("응시 가능 시간이 아닙니다", str(response.data["detail"]))
+
+    def test_take_exam_existing_submission(self) -> None:
+        """이미 응시한 경우 기존 submission 반환 테스트"""
+        self.client.force_authenticate(user=self.student_user)
+
+        # 첫 번째 응시
+        response1 = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        submission_id_1 = response1.data["submission_id"]
+
+        # 두 번째 응시 (같은 사용자, 같은 deployment)
+        response2 = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        submission_id_2 = response2.data["submission_id"]
+
+        # 같은 submission이 반환되어야 함
+        self.assertEqual(submission_id_1, submission_id_2)
+        self.assertEqual(
+            ExamSubmission.objects.filter(submitter=self.student_user, deployment=self.deployment).count(), 1
+        )

--- a/apps/exams/tests/test_take_exam.py
+++ b/apps/exams/tests/test_take_exam.py
@@ -14,9 +14,6 @@ from apps.users.models import User
 
 class TakeExamAPITest(APITestCase):
     def setUp(self) -> None:
-        """테스트 데이터 설정"""
-        self.take_exam_url = reverse("exams:take-exam")
-
         self.student_user = User.objects.create_user(
             email="student@test.com",
             password="testpass123",
@@ -27,7 +24,6 @@ class TakeExamAPITest(APITestCase):
             birthday="2000-01-01",
             role=User.Role.STUDENT,
         )
-
         self.admin_user = User.objects.create_user(
             email="admin@test.com",
             password="testpass123",
@@ -38,8 +34,6 @@ class TakeExamAPITest(APITestCase):
             birthday="1990-01-01",
             role=User.Role.ADMIN,
         )
-
-        # Course, Subject, Cohort 생성
         self.course = Course.objects.create(name="테스트 강좌")
         self.subject = Subject.objects.create(
             course=self.course, title="테스트 과목", number_of_days=30, number_of_hours=120
@@ -51,15 +45,11 @@ class TakeExamAPITest(APITestCase):
             start_date="2025-01-01",
             end_date="2025-12-31",
         )
-
-        # Exam 생성
         self.exam = Exam.objects.create(
             title="테스트 시험",
             thumbnail_img_url="https://example.com/thumb.jpg",
             subject=self.subject,
         )
-
-        # ExamDeployment 생성 (활성화, 응시 가능 시간 내)
         now = timezone.now()
         self.deployment = ExamDeployment.objects.create(
             exam=self.exam,
@@ -68,114 +58,79 @@ class TakeExamAPITest(APITestCase):
             access_code="testcode123",
             open_at=now - timedelta(hours=1),
             close_at=now + timedelta(hours=1),
-            questions_snapshot_json={"questions": []},
+            questions_snapshot_json=[],
             status=ExamDeployment.StatusChoices.ACTIVATED,
         )
 
+    def _take_exam_url(self) -> str:
+        return reverse("exams:take-exam", kwargs={"deployment_id": self.deployment.id})
+
     def test_take_exam_success(self) -> None:
-        """응시 성공 테스트"""
         self.client.force_authenticate(user=self.student_user)
-        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-
+        response = self.client.get(self._take_exam_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("submission_id", response.data)
-        self.assertIn("deployment_id", response.data)
         self.assertIn("exam_id", response.data)
+        self.assertIn("exam_name", response.data)
+        self.assertIn("duration_time", response.data)
+        self.assertIn("elapsed_time", response.data)
+        self.assertIn("cheating_count", response.data)
+        self.assertIn("questions", response.data)
         self.assertEqual(response.data["exam_id"], self.exam.id)
-        self.assertEqual(response.data["deployment_id"], self.deployment.id)
-
-        # DB에 submission이 생성되었는지 확인
+        self.assertEqual(response.data["exam_name"], self.exam.title)
+        self.assertEqual(response.data["duration_time"], 60)
+        self.assertIsInstance(response.data["questions"], list)
         submission = ExamSubmission.objects.get(submitter=self.student_user, deployment=self.deployment)
         self.assertEqual(submission.deployment, self.deployment)
 
-    def test_take_exam_invalid_access_code(self) -> None:
-        """잘못된 참가코드 테스트"""
-        self.client.force_authenticate(user=self.student_user)
-        response = self.client.post(self.take_exam_url, {"access_code": "invalid_code"}, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("detail", response.data)
-        self.assertIn("참가 코드가 올바르지 않습니다", str(response.data["detail"]))
-
-    def test_take_exam_missing_access_code(self) -> None:
-        """참가코드 필드 누락 테스트"""
-        self.client.force_authenticate(user=self.student_user)
-        response = self.client.post(self.take_exam_url, {}, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("access_code", response.data)
-
     def test_take_exam_non_student_role(self) -> None:
-        """수강생이 아닌 사용자 테스트"""
         self.client.force_authenticate(user=self.admin_user)
-        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-
+        response = self.client.get(self._take_exam_url())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.data)
         self.assertIn("수강생 권한이 필요합니다", str(response.data["detail"]))
 
     def test_take_exam_unauthenticated(self) -> None:
-        """인증되지 않은 사용자 테스트"""
-        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-
+        response = self.client.get(self._take_exam_url())
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_take_exam_deactivated_status(self) -> None:
-        """비활성화된 시험 테스트"""
         self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
         self.deployment.save()
-
         self.client.force_authenticate(user=self.student_user)
-        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-
+        response = self.client.get(self._take_exam_url())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.data)
         self.assertIn("현재 응시할 수 없는 시험입니다", str(response.data["detail"]))
 
     def test_take_exam_before_open_time(self) -> None:
-        """응시 시작 시간 전 테스트"""
         now = timezone.now()
         self.deployment.open_at = now + timedelta(hours=1)
         self.deployment.close_at = now + timedelta(hours=2)
         self.deployment.save()
-
         self.client.force_authenticate(user=self.student_user)
-        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-
+        response = self.client.get(self._take_exam_url())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.data)
-        self.assertIn("응시 가능 시간이 아닙니다", str(response.data["detail"]))
+        self.assertIn("아직 응시할 수 없습니다", str(response.data["detail"]))
 
     def test_take_exam_after_close_time(self) -> None:
-        """응시 종료 시간 후 테스트"""
         now = timezone.now()
         self.deployment.open_at = now - timedelta(hours=2)
         self.deployment.close_at = now - timedelta(hours=1)
         self.deployment.save()
-
         self.client.force_authenticate(user=self.student_user)
-        response = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-
+        response = self.client.get(self._take_exam_url())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.data)
-        self.assertIn("응시 가능 시간이 아닙니다", str(response.data["detail"]))
+        self.assertIn("시험이 종료되었습니다", str(response.data["detail"]))
 
     def test_take_exam_existing_submission(self) -> None:
-        """이미 응시한 경우 기존 submission 반환 테스트"""
         self.client.force_authenticate(user=self.student_user)
-
-        # 첫 번째 응시
-        response1 = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-        self.assertEqual(response1.status_code, status.HTTP_200_OK)
-        submission_id_1 = response1.data["submission_id"]
-
-        # 두 번째 응시 (같은 사용자, 같은 deployment)
-        response2 = self.client.post(self.take_exam_url, {"access_code": "testcode123"}, format="json")
-        self.assertEqual(response2.status_code, status.HTTP_200_OK)
-        submission_id_2 = response2.data["submission_id"]
-
-        # 같은 submission이 반환되어야 함
-        self.assertEqual(submission_id_1, submission_id_2)
+        r1 = self.client.get(self._take_exam_url())
+        self.assertEqual(r1.status_code, status.HTTP_200_OK)
+        r2 = self.client.get(self._take_exam_url())
+        self.assertEqual(r2.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            ExamSubmission.objects.filter(submitter=self.student_user, deployment=self.deployment).count(), 1
+            ExamSubmission.objects.filter(submitter=self.student_user, deployment=self.deployment).count(),
+            1,
         )

--- a/apps/exams/tests/test_take_exam.py
+++ b/apps/exams/tests/test_take_exam.py
@@ -41,7 +41,9 @@ class TakeExamAPITest(APITestCase):
 
         # Course, Subject, Cohort 생성
         self.course = Course.objects.create(name="테스트 강좌")
-        self.subject = Subject.objects.create(course=self.course, name="테스트 과목")
+        self.subject = Subject.objects.create(
+            course=self.course, title="테스트 과목", number_of_days=30, number_of_hours=120
+        )
         self.cohort = Cohort.objects.create(
             course=self.course,
             number=1,

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 
 from apps.exams.views import CheckCodeAPIView, ExamListView, TakeExamAPIView
+from apps.exams.views.cheating_views import ExamCheatingUpdateAPIView
+from apps.exams.views.status_views import ExamStatusCheckAPIView
 
 app_name = "exams"
 
@@ -8,4 +10,6 @@ urlpatterns = [
     path("deployments", ExamListView.as_view(), name="exam-deployments"),
     path("deployments/<int:deployment_id>", TakeExamAPIView.as_view(), name="take-exam"),
     path("deployments/<int:deployment_id>/check_code", CheckCodeAPIView.as_view(), name="check-code"),
+    path("deployments/<int:deployment_id>/status/", ExamStatusCheckAPIView.as_view(), name="exam-status"),
+    path("deployments/<int:deployment_id>/cheating/", ExamCheatingUpdateAPIView.as_view(), name="exam-cheating"),
 ]

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -1,12 +1,11 @@
 from django.urls import path
 
-from apps.exams.views.cheating_views import ExamCheatingUpdateAPIView
-from apps.exams.views.exam_list import ExamListView
-from apps.exams.views.status_views import ExamStatusCheckAPIView
+from apps.exams.views import CheckCodeAPIView, ExamListView, TakeExamAPIView
+
+app_name = "exams"
 
 urlpatterns = [
-    path("deployments/<int:deployment_id>/status/", ExamStatusCheckAPIView.as_view(), name="exam-status"),
-    path("deployments/<int:deployment_id>/cheating/", ExamCheatingUpdateAPIView.as_view(), name="exam-cheating"),
     path("deployments", ExamListView.as_view(), name="exam-deployments"),
-    path("api/v1/exams/deployments", ExamListView.as_view(), name="exam-deployments"),
+    path("deployments/<int:deployment_id>", TakeExamAPIView.as_view(), name="take-exam"),
+    path("deployments/<int:deployment_id>/check_code", CheckCodeAPIView.as_view(), name="check-code"),
 ]

--- a/apps/exams/views/__init__.py
+++ b/apps/exams/views/__init__.py
@@ -1,7 +1,13 @@
+from .check_code import CheckCodeAPIView
 from .exam_list import ExamListView
+from .exam_status import ExamStatusAPIView
+from .submit_exam import SubmitExamAPIView
 from .take_exam import TakeExamAPIView
 
 __all__ = [
+    "CheckCodeAPIView",
     "ExamListView",
+    "ExamStatusAPIView",
+    "SubmitExamAPIView",
     "TakeExamAPIView",
 ]

--- a/apps/exams/views/__init__.py
+++ b/apps/exams/views/__init__.py
@@ -1,5 +1,7 @@
+from .exam_list import ExamListView
 from .take_exam import TakeExamAPIView
 
 __all__ = [
+    "ExamListView",
     "TakeExamAPIView",
 ]

--- a/apps/exams/views/__init__.py
+++ b/apps/exams/views/__init__.py
@@ -1,0 +1,5 @@
+from .take_exam import TakeExamAPIView
+
+__all__ = [
+    "TakeExamAPIView",
+]

--- a/apps/exams/views/admin_question_views.py
+++ b/apps/exams/views/admin_question_views.py
@@ -64,6 +64,4 @@ class AdminExamQuestionCreateAPIView(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        response_serializer = AdminExamQuestionCreateResponseSerializer(data=result)
-        response_serializer.is_valid(raise_exception=True)
-        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+        return Response(AdminExamQuestionCreateResponseSerializer(result).data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/check_code.py
+++ b/apps/exams/views/check_code.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.models import ExamDeployment
+from apps.exams.serializers import CheckCodeRequestSerializer
+from apps.users.models import User
+
+
+class CheckCodeAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request, deployment_id: int) -> Response:
+        serializer = CheckCodeRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            deployment = ExamDeployment.objects.get(id=deployment_id)
+        except ExamDeployment.DoesNotExist:
+            return Response(
+                {"error_detail": "해당 시험 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # 참가 코드 검증
+        if deployment.access_code != serializer.validated_data["code"]:
+            return Response(
+                {"error_detail": "응시 코드가 일치하지 않습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 권한 확인 (수강생만)
+        if request.user.role != User.Role.STUDENT:
+            return Response(
+                {"error_detail": "시험에 응시할 권한이 없습니다."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # 시험 상태 확인
+        if deployment.status != ExamDeployment.StatusChoices.ACTIVATED:
+            return Response(
+                {"error_detail": "현재 응시할 수 없는 시험입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 시험 시간 확인
+        now = timezone.now()
+        if now < deployment.open_at:
+            return Response(
+                {"error_detail": "아직 응시할 수 없습니다."},
+                status=status.HTTP_423_LOCKED,
+            )
+
+        # 검증 성공 - 204 No Content 반환
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/exams/views/check_code.py
+++ b/apps/exams/views/check_code.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -11,12 +12,27 @@ from rest_framework.views import APIView
 
 from apps.exams.models import ExamDeployment
 from apps.exams.serializers import CheckCodeRequestSerializer
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.users.models import User
 
 
 class CheckCodeAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        tags=["exams"],
+        summary="참가코드 검증 API",
+        description="시험 참가코드를 검증합니다.",
+        request=CheckCodeRequestSerializer,
+        responses={
+            204: OpenApiResponse(description="검증 성공"),
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 코드 또는 시험 상태"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="응시 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+            423: OpenApiResponse(ErrorResponseSerializer, description="시험 시작 시간 전"),
+        },
+    )
     def post(self, request: Request, deployment_id: int) -> Response:
         serializer = CheckCodeRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -57,6 +73,11 @@ class CheckCodeAPIView(APIView):
             return Response(
                 {"error_detail": "아직 응시할 수 없습니다."},
                 status=status.HTTP_423_LOCKED,
+            )
+        if now > deployment.close_at:
+            return Response(
+                {"error_detail": "시험이 이미 종료되었습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         # 검증 성공 - 204 No Content 반환

--- a/apps/exams/views/check_code.py
+++ b/apps/exams/views/check_code.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -35,7 +37,8 @@ class CheckCodeAPIView(APIView):
             )
 
         # 권한 확인 (수강생만)
-        if request.user.role != User.Role.STUDENT:
+        user = cast(User, request.user)
+        if user.role != User.Role.STUDENT:
             return Response(
                 {"error_detail": "시험에 응시할 권한이 없습니다."},
                 status=status.HTTP_403_FORBIDDEN,

--- a/apps/exams/views/exam_status.py
+++ b/apps/exams/views/exam_status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -10,12 +11,25 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.exams.models import ExamDeployment, ExamSubmission
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.serializers.exam_status import ExamStatusResponseSerializer
 from apps.users.models import User
 
 
 class ExamStatusAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        tags=["exams"],
+        summary="시험 상태 조회 API",
+        description="시험 응시 상태를 조회합니다.",
+        responses={
+            200: ExamStatusResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 시험 응시 세션"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+        },
+    )
     def get(self, request: Request, deployment_id: int) -> Response:
         try:
             deployment = ExamDeployment.objects.get(id=deployment_id)
@@ -42,9 +56,11 @@ class ExamStatusAPIView(APIView):
         force_submit = closed
 
         return Response(
-            {
-                "exam_status": "closed" if closed else "in_progress",
-                "force_submit": force_submit,
-            },
+            ExamStatusResponseSerializer(
+                {
+                    "exam_status": "closed" if closed else "in_progress",
+                    "force_submit": force_submit,
+                }
+            ).data,
             status=status.HTTP_200_OK,
         )

--- a/apps/exams/views/exam_status.py
+++ b/apps/exams/views/exam_status.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -8,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.exams.models import ExamDeployment, ExamSubmission
+from apps.users.models import User
 
 
 class ExamStatusAPIView(APIView):
@@ -22,8 +25,9 @@ class ExamStatusAPIView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
+        user = cast(User, request.user)
         submission = ExamSubmission.objects.filter(
-            submitter=request.user,
+            submitter=user,
             deployment=deployment,
         ).first()
 

--- a/apps/exams/views/exam_status.py
+++ b/apps/exams/views/exam_status.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.models import ExamDeployment, ExamSubmission
+
+
+class ExamStatusAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request, deployment_id: int) -> Response:
+        try:
+            deployment = ExamDeployment.objects.get(id=deployment_id)
+        except ExamDeployment.DoesNotExist:
+            return Response(
+                {"error_detail": "해당 시험 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        submission = ExamSubmission.objects.filter(
+            submitter=request.user,
+            deployment=deployment,
+        ).first()
+
+        if not submission:
+            return Response(
+                {"error_detail": "유효하지 않은 시험 응시 세션입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        now = timezone.now()
+        closed = deployment.status != ExamDeployment.StatusChoices.ACTIVATED or now > deployment.close_at
+        force_submit = closed
+
+        return Response(
+            {
+                "exam_status": "closed" if closed else "in_progress",
+                "force_submit": force_submit,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/apps/exams/views/submit_exam.py
+++ b/apps/exams/views/submit_exam.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.serializers.submit_exam import SubmitExamRequestSerializer
+from apps.exams.services.submit_exam import submit_exam
+
+
+class SubmitExamAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        serializer = SubmitExamRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        answers = [dict(a) for a in data["answers"]]
+        submission = submit_exam(
+            user=request.user,
+            deployment_id=data["deployment_id"],
+            started_at=data.get("started_at"),
+            answers=answers,
+        )
+
+        return Response(
+            {
+                "submission_id": submission.id,
+                "correct_answer_count": submission.correct_answer_count,
+                "result_url": f"/api/v1/exams/submissions/{submission.id}/result",
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/apps/exams/views/submit_exam.py
+++ b/apps/exams/views/submit_exam.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -8,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.exams.serializers.submit_exam import SubmitExamRequestSerializer
 from apps.exams.services.submit_exam import submit_exam
+from apps.users.models import User
 
 
 class SubmitExamAPIView(APIView):
@@ -19,8 +22,9 @@ class SubmitExamAPIView(APIView):
         data = serializer.validated_data
 
         answers = [dict(a) for a in data["answers"]]
+        user = cast(User, request.user)
         submission = submit_exam(
-            user=request.user,
+            user=user,
             deployment_id=data["deployment_id"],
             started_at=data.get("started_at"),
             answers=answers,

--- a/apps/exams/views/submit_exam.py
+++ b/apps/exams/views/submit_exam.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 from typing import cast
 
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.exams.serializers.submit_exam import SubmitExamRequestSerializer
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.serializers.submit_exam import (
+    SubmitExamRequestSerializer,
+    SubmitExamResponseSerializer,
+)
 from apps.exams.services.submit_exam import submit_exam
 from apps.users.models import User
 
@@ -16,6 +21,19 @@ from apps.users.models import User
 class SubmitExamAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        tags=["exams"],
+        summary="시험 제출 API",
+        description="시험 답안을 제출합니다.",
+        request=SubmitExamRequestSerializer,
+        responses={
+            201: SubmitExamResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청 또는 이미 제출된 시험"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="제출 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+        },
+    )
     def post(self, request: Request) -> Response:
         serializer = SubmitExamRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -31,10 +49,13 @@ class SubmitExamAPIView(APIView):
         )
 
         return Response(
-            {
-                "submission_id": submission.id,
-                "correct_answer_count": submission.correct_answer_count,
-                "result_url": f"/api/v1/exams/submissions/{submission.id}/result",
-            },
+            SubmitExamResponseSerializer(
+                {
+                    "submission_id": submission.id,
+                    "correct_answer_count": submission.correct_answer_count,
+                    "score": submission.score,
+                    "redirect_url": f"/api/v1/exams/submissions/{submission.id}/result",
+                }
+            ).data,
             status=status.HTTP_201_CREATED,
         )

--- a/apps/exams/views/take_exam.py
+++ b/apps/exams/views/take_exam.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import cast
 
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.exams.serializers import TakeExamRequestSerializer, TakeExamResponseSerializer
+from apps.exams.serializers import TakeExamResponseSerializer
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.services import build_take_exam_response, take_exam
 from apps.users.models import User
 
@@ -15,9 +18,21 @@ from apps.users.models import User
 class TakeExamAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        tags=["exams"],
+        summary="시험 응시 API",
+        description="시험을 응시하고 문제 목록을 조회합니다.",
+        responses={
+            200: TakeExamResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="응시 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+        },
+    )
     def get(self, request: Request, deployment_id: int) -> Response:
         user = cast(User, request.user)
         result = take_exam(user=user, deployment_id=deployment_id)
         payload = build_take_exam_response(result=result)
 
-        return Response(TakeExamResponseSerializer(payload).data, status=200)
+        return Response(TakeExamResponseSerializer(payload).data, status=status.HTTP_200_OK)

--- a/apps/exams/views/take_exam.py
+++ b/apps/exams/views/take_exam.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.exams.serializers import TakeExamRequestSerializer, TakeExamResponseSerializer
 from apps.exams.services import build_take_exam_response, take_exam
 
 
@@ -14,4 +15,5 @@ class TakeExamAPIView(APIView):
     def get(self, request: Request, deployment_id: int) -> Response:
         result = take_exam(user=request.user, deployment_id=deployment_id)
         payload = build_take_exam_response(result=result)
-        return Response(payload, status=200)
+
+        return Response(TakeExamResponseSerializer(payload).data, status=200)

--- a/apps/exams/views/take_exam.py
+++ b/apps/exams/views/take_exam.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -7,13 +9,15 @@ from rest_framework.views import APIView
 
 from apps.exams.serializers import TakeExamRequestSerializer, TakeExamResponseSerializer
 from apps.exams.services import build_take_exam_response, take_exam
+from apps.users.models import User
 
 
 class TakeExamAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request, deployment_id: int) -> Response:
-        result = take_exam(user=request.user, deployment_id=deployment_id)
+        user = cast(User, request.user)
+        result = take_exam(user=user, deployment_id=deployment_id)
         payload = build_take_exam_response(result=result)
 
         return Response(TakeExamResponseSerializer(payload).data, status=200)

--- a/apps/exams/views/take_exam.py
+++ b/apps/exams/views/take_exam.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.serializers import TakeExamRequestSerializer, TakeExamResponseSerializer
+from apps.exams.services import build_take_exam_response, take_exam
+
+
+class TakeExamAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        req_serializer = TakeExamRequestSerializer(data=request.data)
+        req_serializer.is_valid(raise_exception=True)
+
+        result = take_exam(user=request.user, access_code=req_serializer.validated_data["access_code"])
+        payload = build_take_exam_response(result=result)
+
+        res_serializer = TakeExamResponseSerializer(data=payload)
+        res_serializer.is_valid(raise_exception=True)
+        return Response(res_serializer.data, status=200)

--- a/apps/exams/views/take_exam.py
+++ b/apps/exams/views/take_exam.py
@@ -5,25 +5,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.exams.serializers import TakeExamRequestSerializer, TakeExamResponseSerializer
 from apps.exams.services import build_take_exam_response, take_exam
 
 
 class TakeExamAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def post(self, request: Request) -> Response:
-        req_serializer = TakeExamRequestSerializer(data=request.data)
-        req_serializer.is_valid(raise_exception=True)
-
-        if not request.user.is_authenticated or not hasattr(request.user, "role"):
-            from rest_framework.exceptions import AuthenticationFailed
-
-            raise AuthenticationFailed("인증이 필요합니다.")
-
-        result = take_exam(user=request.user, access_code=req_serializer.validated_data["access_code"])
+    def get(self, request: Request, deployment_id: int) -> Response:
+        result = take_exam(user=request.user, deployment_id=deployment_id)
         payload = build_take_exam_response(result=result)
-
-        res_serializer = TakeExamResponseSerializer(data=payload)
-        res_serializer.is_valid(raise_exception=True)
-        return Response(res_serializer.data, status=200)
+        return Response(payload, status=200)

--- a/apps/exams/views/take_exam.py
+++ b/apps/exams/views/take_exam.py
@@ -16,6 +16,11 @@ class TakeExamAPIView(APIView):
         req_serializer = TakeExamRequestSerializer(data=request.data)
         req_serializer.is_valid(raise_exception=True)
 
+        if not request.user.is_authenticated or not hasattr(request.user, "role"):
+            from rest_framework.exceptions import AuthenticationFailed
+
+            raise AuthenticationFailed("인증이 필요합니다.")
+
         result = take_exam(user=request.user, access_code=req_serializer.validated_data["access_code"])
         payload = build_take_exam_response(result=result)
 

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -17,3 +17,12 @@ MEDIA_ROOT = BASE_DIR / "media"
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+# 이메일 설정
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.gmail.com")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() == "true"
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,3 +1,5 @@
+import os
+
 from config.settings.base import *
 
 DEBUG = True
@@ -22,7 +24,7 @@ INTERNAL_IPS = [
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.gmail.com")
 EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
-EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER") or ""
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD") or ""
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() == "true"
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL") or EMAIL_HOST_USER

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,14 +9,11 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("api/exams/", include("apps.exams.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/accounts/", include("apps.users.urls")),
-    path("", include("apps.exams.urls")),
     path("api/v1/admin/exams/", include("apps.exams.admin_urls")),
     path("api/v1/exams/", include("apps.exams.urls")),
 ]
-
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## ✅ PR 요약
- 쪽지시험 응시 기능 구현
- 참가코드 검증 기능 포함
- 관련 이슈: REQ-TEST-002

## 📄 상세 내용
- [x] 참가코드 검증 로직 구현
- [x] 응시 진입 API 구현 (POST /api/v1/exams/take/)
- [x] 통합 테스트 작성 (APITestCase 사용)
- [x] 코드 포맷팅 (black, isort) 완료

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 로컬 환경 DB 설정 문제로 테스트는 CI에서 실행 예정
- 모든 코드 포맷팅(black, isort) 완료

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). "CI에서 실행 예정" 
