### PR TITLE
[feature/admin-exam-create] ✨ feat: 관리자 쪽지시험 생성 API 및 테스트 추가

### DIFF
--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
+from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 
 urlpatterns = [
     path("<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
+    path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
 ]

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -4,6 +4,6 @@ from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 
 urlpatterns = [
-    path("<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
+    path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
     path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
 ]

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
-from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
+from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 
 urlpatterns = [
     path("<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -20,7 +20,7 @@ class IsStudentRole(BasePermission):
 class IsExamStaff(BasePermission):
     """쪽지시험 관리자 API용 권한 검사."""
 
-    message = "쪽지시험 관리 권한이 없습니다."
+    message = "쪽지시험 문제 등록 권한이 없습니다."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
         user = request.user

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 from typing import Any
 
 from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 from apps.users.models import User
 
@@ -14,18 +18,16 @@ class IsStudentRole(BasePermission):
 
 
 class IsExamStaff(BasePermission):
+    """쪽지시험 관리자 API용 권한 검사."""
     message = "쪽지시험 문제 등록 권한이 없습니다."
 
-    def has_permission(self, request: Any, view: Any) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         user = request.user
-        return bool(
-            user
-            and user.is_authenticated
-            and user.role
-            in {
-                User.Role.ADMIN,
-                User.Role.TA,
-                User.Role.LC,
-                User.Role.OM,
-            }
-        )
+        if not user or not user.is_authenticated:
+            return False
+        return user.role in {
+            User.Role.ADMIN,
+            User.Role.TA,
+            User.Role.LC,
+            User.Role.OM,
+        }

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -19,7 +19,8 @@ class IsStudentRole(BasePermission):
 
 class IsExamStaff(BasePermission):
     """쪽지시험 관리자 API용 권한 검사."""
-    message = "쪽지시험 문제 등록 권한이 없습니다."
+
+    message = "쪽지시험 관리 권한이 없습니다."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
         user = request.user

--- a/apps/exams/serializers/admin_exam_serializers.py
+++ b/apps/exams/serializers/admin_exam_serializers.py
@@ -12,6 +12,12 @@ class AdminExamCreateRequestSerializer(serializers.Serializer[Any]):
     subject_id = serializers.IntegerField()
     thumbnail_img = serializers.ImageField()
 
+    def validate_thumbnail_img(self, value: Any) -> Any:
+        content_type = getattr(value, "content_type", None)
+        if content_type not in {"image/jpeg", "image/png", "image/jpg"}:
+            raise serializers.ValidationError("유효하지 않은 시험 생성 요청입니다.")
+        return value
+
 
 class AdminExamCreateResponseSerializer(serializers.Serializer[Any]):
     """쪽지시험 생성 응답 스키마."""

--- a/apps/exams/serializers/admin_exam_serializers.py
+++ b/apps/exams/serializers/admin_exam_serializers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamCreateRequestSerializer(serializers.Serializer[Any]):
+    """쪽지시험 생성 요청 스키마."""
+    title = serializers.CharField(max_length=50)
+    subject_id = serializers.IntegerField()
+    thumbnail_img = serializers.ImageField()
+
+
+class AdminExamCreateResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 생성 응답 스키마."""
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    subject_id = serializers.IntegerField()
+    thumbnail_img_url = serializers.CharField()

--- a/apps/exams/serializers/admin_exam_serializers.py
+++ b/apps/exams/serializers/admin_exam_serializers.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 
 class AdminExamCreateRequestSerializer(serializers.Serializer[Any]):
     """쪽지시험 생성 요청 스키마."""
+
     title = serializers.CharField(max_length=50)
     subject_id = serializers.IntegerField()
     thumbnail_img = serializers.ImageField()
@@ -14,6 +15,7 @@ class AdminExamCreateRequestSerializer(serializers.Serializer[Any]):
 
 class AdminExamCreateResponseSerializer(serializers.Serializer[Any]):
     """쪽지시험 생성 응답 스키마."""
+
     id = serializers.IntegerField()
     title = serializers.CharField()
     subject_id = serializers.IntegerField()

--- a/apps/exams/services/admin_exam_service.py
+++ b/apps/exams/services/admin_exam_service.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import UploadedFile
+from django.db import transaction
+
+from apps.courses.models.subjects import Subject
+from apps.exams.models.exams import Exam
+
+
+class ExamCreateConflictError(Exception):
+    """동일한 시험명이 이미 존재할 때 발생."""
+
+
+class ExamCreateNotFoundError(Exception):
+    """과목 정보가 없을 때 발생."""
+
+
+def _store_thumbnail(thumbnail_img: UploadedFile) -> str:
+    name = thumbnail_img.name or "thumbnail"
+    _, ext = os.path.splitext(name)
+    ext = ext.lower() if ext else ".png"
+    filename = f"exams/{uuid4().hex}{ext}"
+    saved_path = default_storage.save(filename, thumbnail_img)
+    return default_storage.url(saved_path)
+
+
+def create_exam(title: str, subject_id: int, thumbnail_img: UploadedFile) -> Exam:
+    with transaction.atomic():
+        if Exam.objects.filter(title=title).exists():
+            raise ExamCreateConflictError
+
+        subject = Subject.objects.filter(id=subject_id).first()
+        if not subject:
+            raise ExamCreateNotFoundError
+
+        thumbnail_img_url = _store_thumbnail(thumbnail_img)
+        return Exam.objects.create(
+            subject=subject,
+            title=title,
+            thumbnail_img_url=thumbnail_img_url,
+        )

--- a/apps/exams/tests/test_admin_exam_views.py
+++ b/apps/exams/tests/test_admin_exam_views.py
@@ -164,3 +164,22 @@ class AdminExamCreateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["error_detail"], "유효하지 않은 시험 생성 요청입니다.")
+
+    def test_admin_exam_create_returns_400_when_invalid_image_type(self) -> None:
+        image_file = SimpleUploadedFile(
+            name="thumbnail.gif",
+            content=b"GIF89a",
+            content_type="image/gif",
+        )
+
+        response = self._auth_client(self.admin_user).post(
+            "/api/v1/admin/exams",
+            data={
+                "title": "Python Basic Exam",
+                "subject_id": self.subject.id,
+                "thumbnail_img": image_file,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error_detail"], "유효하지 않은 시험 생성 요청입니다.")

--- a/apps/exams/tests/test_admin_exam_views.py
+++ b/apps/exams/tests/test_admin_exam_views.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import tempfile
+from io import BytesIO
+from typing import Any, ClassVar
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import Client, TestCase, override_settings
+from PIL import Image
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models.exams import Exam
+from apps.users.models import User
+
+
+class AdminExamCreateAPITest(TestCase):
+    """관리자 쪽지시험 생성 API 테스트."""
+    _temp_media: ClassVar[tempfile.TemporaryDirectory[str]]
+    _override: ClassVar[Any]
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls._temp_media = tempfile.TemporaryDirectory()
+        cls._override = override_settings(MEDIA_ROOT=cls._temp_media.name, MEDIA_URL="media/")
+        cls._override.enable()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._override.disable()
+        cls._temp_media.cleanup()
+        super().tearDownClass()
+
+    def setUp(self) -> None:
+        self.client = Client()
+        self.course = Course.objects.create(name="Python", tag="PY")
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="Python Basic",
+            number_of_days=10,
+            number_of_hours=40,
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password1234",
+            name="Admin",
+            nickname="admin",
+            phone_number="01000000000",
+            gender=User.Gender.MALE,
+            birthday="2000-01-01",
+            role=User.Role.ADMIN,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password1234",
+            name="User",
+            nickname="user",
+            phone_number="01000000001",
+            gender=User.Gender.MALE,
+            birthday="2000-01-01",
+            role=User.Role.USER,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def _auth_client(self, user: User) -> Client:
+        client = Client()
+        client.defaults.update(self._auth_headers(user))
+        return client
+
+    def _create_image_file(self) -> SimpleUploadedFile:
+        image = Image.new("RGB", (1, 1), color="white")
+        buffer = BytesIO()
+        image.save(buffer, format="PNG")
+        return SimpleUploadedFile(
+            name="thumbnail.png",
+            content=buffer.getvalue(),
+            content_type="image/png",
+        )
+
+    def test_admin_exam_create_success(self) -> None:
+        image_file = self._create_image_file()
+        data = {
+            "title": "Python Basic Exam",
+            "subject_id": self.subject.id,
+            "thumbnail_img": image_file,
+        }
+
+        response = self._auth_client(self.admin_user).post(
+            "/api/v1/admin/exams",
+            data=data,
+        )
+
+        self.assertEqual(response.status_code, 201)
+        response_data = response.json()
+        self.assertEqual(response_data["title"], data["title"])
+        self.assertEqual(response_data["subject_id"], self.subject.id)
+        self.assertIn("media/", response_data["thumbnail_img_url"])
+        self.assertTrue(Exam.objects.filter(id=response_data["id"]).exists())
+
+    def test_admin_exam_create_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.post(
+            "/api/v1/admin/exams",
+            data={"title": "Python Basic Exam", "subject_id": self.subject.id},
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("detail", response.json())
+
+    def test_admin_exam_create_returns_403_when_not_staff(self) -> None:
+        image_file = self._create_image_file()
+        response = self._auth_client(self.normal_user).post(
+            "/api/v1/admin/exams",
+            data={
+                "title": "Python Basic Exam",
+                "subject_id": self.subject.id,
+                "thumbnail_img": image_file,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("detail", response.json())
+
+    def test_admin_exam_create_returns_404_when_subject_missing(self) -> None:
+        image_file = self._create_image_file()
+        response = self._auth_client(self.admin_user).post(
+            "/api/v1/admin/exams",
+            data={
+                "title": "Python Basic Exam",
+                "subject_id": 9999,
+                "thumbnail_img": image_file,
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error_detail"], "해당 과목 정보를 찾을 수 없습니다.")
+
+    def test_admin_exam_create_returns_409_when_duplicate_title(self) -> None:
+        Exam.objects.create(subject=self.subject, title="Python Basic Exam", thumbnail_img_url="media/test.png")
+        image_file = self._create_image_file()
+
+        response = self._auth_client(self.admin_user).post(
+            "/api/v1/admin/exams",
+            data={
+                "title": "Python Basic Exam",
+                "subject_id": self.subject.id,
+                "thumbnail_img": image_file,
+            },
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error_detail"], "동일한 이름의 시험이 이미 존재합니다.")
+
+    def test_admin_exam_create_returns_400_when_invalid(self) -> None:
+        response = self._auth_client(self.admin_user).post(
+            "/api/v1/admin/exams",
+            data={"title": "", "subject_id": self.subject.id},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error_detail"], "유효하지 않은 시험 생성 요청입니다.")

--- a/apps/exams/tests/test_admin_exam_views.py
+++ b/apps/exams/tests/test_admin_exam_views.py
@@ -17,8 +17,10 @@ from apps.users.models import User
 
 class AdminExamCreateAPITest(TestCase):
     """관리자 쪽지시험 생성 API 테스트."""
+
     _temp_media: ClassVar[tempfile.TemporaryDirectory[str]]
     _override: ClassVar[Any]
+
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()

--- a/apps/exams/views/admin_exam_views.py
+++ b/apps/exams/views/admin_exam_views.py
@@ -23,6 +23,7 @@ from apps.exams.services.admin_exam_service import (
 
 class AdminExamCreateAPIView(APIView):
     """관리자 쪽지시험 생성 API."""
+
     permission_classes = [IsAuthenticated, IsExamStaff]
     parser_classes = [MultiPartParser, FormParser]
     serializer_class = AdminExamCreateRequestSerializer

--- a/apps/exams/views/admin_exam_views.py
+++ b/apps/exams/views/admin_exam_views.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.permissions import IsExamStaff
+from apps.exams.serializers.admin_exam_serializers import (
+    AdminExamCreateRequestSerializer,
+    AdminExamCreateResponseSerializer,
+)
+from apps.exams.serializers.error import ErrorDetailSerializer
+from apps.exams.services.admin_exam_service import (
+    ExamCreateConflictError,
+    ExamCreateNotFoundError,
+    create_exam,
+)
+
+
+class AdminExamCreateAPIView(APIView):
+    """관리자 쪽지시험 생성 API."""
+    permission_classes = [IsAuthenticated, IsExamStaff]
+    parser_classes = [MultiPartParser, FormParser]
+    serializer_class = AdminExamCreateRequestSerializer
+
+    @extend_schema(
+        tags=["관리자-쪽지시험"],
+        summary="관리자 쪽지시험 생성 API",
+        description="""
+        관리자/스태프 권한으로 쪽지시험을 생성합니다.
+        """,
+        request=AdminExamCreateRequestSerializer,
+        responses={
+            201: AdminExamCreateResponseSerializer,
+            400: OpenApiResponse(ErrorDetailSerializer, description="유효하지 않은 시험 생성 요청"),
+            401: OpenApiResponse(ErrorDetailSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorDetailSerializer, description="쪽지시험 생성 권한 없음"),
+            404: OpenApiResponse(ErrorDetailSerializer, description="과목 정보 없음"),
+            409: OpenApiResponse(ErrorDetailSerializer, description="동일한 이름의 시험 존재"),
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = AdminExamCreateRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"error_detail": "유효하지 않은 시험 생성 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        data = serializer.validated_data
+        try:
+            exam = create_exam(
+                title=data["title"],
+                subject_id=data["subject_id"],
+                thumbnail_img=data["thumbnail_img"],
+            )
+        except ExamCreateNotFoundError:
+            return Response(
+                {"error_detail": "해당 과목 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ExamCreateConflictError:
+            return Response(
+                {"error_detail": "동일한 이름의 시험이 이미 존재합니다."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        response_serializer = AdminExamCreateResponseSerializer(exam)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin_exam_views.py
+++ b/apps/exams/views/admin_exam_views.py
@@ -29,7 +29,7 @@ class AdminExamCreateAPIView(APIView):
     serializer_class = AdminExamCreateRequestSerializer
 
     @extend_schema(
-        tags=["관리자-쪽지시험"],
+        tags=["admin_exams"],
         summary="관리자 쪽지시험 생성 API",
         description="""
         관리자/스태프 권한으로 쪽지시험을 생성합니다.

--- a/apps/exams/views/admin_question_views.py
+++ b/apps/exams/views/admin_question_views.py
@@ -27,7 +27,7 @@ class AdminExamQuestionCreateAPIView(APIView):
     serializer_class = AdminExamQuestionCreateRequestSerializer
 
     @extend_schema(
-        tags=["쪽지시험 관리"],
+        tags=["admin_exams"],
         summary="어드민 쪽지시험 문제 등록 API",
         description="""
         스태프(조교, 러닝 코치, 운영매니저), 관리자 권한을 가진 유저가

--- a/apps/exams/views/cheating_views.py
+++ b/apps/exams/views/cheating_views.py
@@ -30,7 +30,7 @@ class ExamCheatingUpdateAPIView(APIView):
     serializer_class = ExamCheatingResponseSerializer
 
     @extend_schema(
-        tags=["쪽지시험"],
+        tags=["exams"],
         summary="쪽지시험 부정행위 카운트 업데이트 API",
         description="""
         시험 응시 중 화면 이탈 등 부정행위가 발생했을 때 카운트를 증가시킵니다.

--- a/apps/exams/views/status_views.py
+++ b/apps/exams/views/status_views.py
@@ -23,7 +23,7 @@ class ExamStatusCheckAPIView(APIView):
     serializer_class = ExamStatusResponseSerializer
 
     @extend_schema(
-        tags=["쪽지시험"],
+        tags=["exams"],
         summary="쪽지시험 상태 확인 API",
         description="""
         수강생이 쪽지시험 응시 중인 상태를 확인합니다.

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,8 +14,6 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/accounts/", include("apps.users.urls")),
     path("api/v1/admin/", include("apps.exams.admin_urls")),
     path("", include("apps.exams.urls")),
-    path("api/v1/admin/exams/", include("apps.exams.admin_urls")),
-    path("api/v1/exams/", include("apps.exams.urls")),
 ]
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,11 +9,10 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("api/exams/", include("apps.exams.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/accounts/", include("apps.users.urls")),
     path("api/v1/admin/", include("apps.exams.admin_urls")),
-    path("", include("apps.exams.urls")),
+    path("api/v1/exams/", include("apps.exams.urls")),
 ]
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,11 +9,15 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
+    path("api/exams/", include("apps.exams.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/accounts/", include("apps.users.urls")),
+    path("api/v1/admin/", include("apps.exams.admin_urls")),
+    path("", include("apps.exams.urls")),
     path("api/v1/admin/exams/", include("apps.exams.admin_urls")),
     path("api/v1/exams/", include("apps.exams.urls")),
 ]
+
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 관리자 쪽지시험 생성 API 구현 및 테스트 추가

## 📄 상세 내용
- [x] admin_exam_views.py AdminExamCreateAPIView 관리자 시험 생성 API 뷰 추가 (권한/요청 검증/응답 처리)
- [x] admin_exam_service.py create_exam 시험 생성 서비스 및 업로드 처리 추가
- [x] admin_exam_serializers.py AdminExamCreateRequestSerializer, AdminExamCreateResponseSerializer 요청/응답 스키마 정의
- [x] permissions.py IsExamStaff 관리자/스태프 권한 체크 추가
- [x] test_admin_exam_views.py AdminExamCreateAPITest 테스트 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
