### PR TITLE
[feature/qna/create questions] feat: 질문 생성 API 구현

### DIFF
--- a/apps/qna/exceptions/question_exception.py
+++ b/apps/qna/exceptions/question_exception.py
@@ -1,0 +1,26 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class QuestionBaseException(APIException):
+    """QnA 앱의 최상위 예외 클래스 (400 Bad Request)"""
+
+    status_code: int = status.HTTP_400_BAD_REQUEST
+    default_detail = "질문 처리 중 오류가 발생했습니다."
+    default_code = "question_error"
+
+
+class QuestionPermissionDeniedException(QuestionBaseException):
+    """권한 부족 예외 (403 Forbidden)"""
+
+    status_code: int = status.HTTP_403_FORBIDDEN
+    default_detail = "해당 질문에 대한 권한이 없습니다."
+    default_code = "permission_denied"
+
+
+class QuestionAuthenticationRequiredException(QuestionBaseException):
+    """인증 필요 예외 (401 Unauthorized)"""
+
+    status_code: int = status.HTTP_401_UNAUTHORIZED
+    default_detail = "인증 정보가 유효하지 않습니다."
+    default_code = "authentication_failed"

--- a/apps/qna/exceptions/question_exception.py
+++ b/apps/qna/exceptions/question_exception.py
@@ -3,7 +3,11 @@ from rest_framework.exceptions import APIException
 
 
 class QuestionBaseException(APIException):
-    """QnA 앱의 최상위 예외 클래스 (400 Bad Request)"""
+    """
+    QnA 앱의 최상위 예외 클래스 (400 Bad Request)
+    DRF 기본 ValidationError 발생은 serializer에서 처리하고,
+    그 외의 예상치 못한 에러를 위한 예외처리 클래스
+    """
 
     status_code: int = status.HTTP_400_BAD_REQUEST
     default_detail = "질문 처리 중 오류가 발생했습니다."
@@ -11,7 +15,9 @@ class QuestionBaseException(APIException):
 
 
 class QuestionPermissionDeniedException(QuestionBaseException):
-    """권한 부족 예외 (403 Forbidden)"""
+    """
+    권한 부족 예외 (403 Forbidden)
+    """
 
     status_code: int = status.HTTP_403_FORBIDDEN
     default_detail = "해당 질문에 대한 권한이 없습니다."
@@ -19,7 +25,9 @@ class QuestionPermissionDeniedException(QuestionBaseException):
 
 
 class QuestionAuthenticationRequiredException(QuestionBaseException):
-    """인증 필요 예외 (401 Unauthorized)"""
+    """
+    인증 필요 예외 (401 Unauthorized)
+    """
 
     status_code: int = status.HTTP_401_UNAUTHORIZED
     default_detail = "인증 정보가 유효하지 않습니다."

--- a/apps/qna/models/answer.py
+++ b/apps/qna/models/answer.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import TimeStampModel
-from apps.users.models import User
-
 from apps.qna.models.question import Question
+from apps.users.models import User
 
 
 class Answer(TimeStampModel):

--- a/apps/qna/models/answer.py
+++ b/apps/qna/models/answer.py
@@ -5,7 +5,7 @@ from django.db import models
 from apps.core.models import TimeStampModel
 from apps.users.models import User
 
-from .question import Question
+from apps.qna.models.question import Question
 
 
 class Answer(TimeStampModel):

--- a/apps/qna/models/answer_comment.py
+++ b/apps/qna/models/answer_comment.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import TimeStampModel
-from apps.users.models import User
-
 from apps.qna.models.answer import Answer
+from apps.users.models import User
 
 
 class AnswerComment(TimeStampModel):

--- a/apps/qna/models/answer_comment.py
+++ b/apps/qna/models/answer_comment.py
@@ -5,7 +5,7 @@ from django.db import models
 from apps.core.models import TimeStampModel
 from apps.users.models import User
 
-from .answer import Answer
+from apps.qna.models.answer import Answer
 
 
 class AnswerComment(TimeStampModel):

--- a/apps/qna/models/answer_image.py
+++ b/apps/qna/models/answer_image.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from apps.core.models import TimeStampModel
 
-from .answer import Answer
+from apps.qna.models.answer import Answer
 
 
 class AnswerImage(TimeStampModel):

--- a/apps/qna/models/answer_image.py
+++ b/apps/qna/models/answer_image.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import TimeStampModel
-
 from apps.qna.models.answer import Answer
 
 

--- a/apps/qna/models/question.py
+++ b/apps/qna/models/question.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import TimeStampModel
-from apps.users.models import User
-
 from apps.qna.models.question_category import QuestionCategory
+from apps.users.models import User
 
 
 class Question(TimeStampModel):

--- a/apps/qna/models/question.py
+++ b/apps/qna/models/question.py
@@ -5,7 +5,7 @@ from django.db import models
 from apps.core.models import TimeStampModel
 from apps.users.models import User
 
-from .question_category import QuestionCategory
+from apps.qna.models.question_category import QuestionCategory
 
 
 class Question(TimeStampModel):

--- a/apps/qna/models/question_ai_answer.py
+++ b/apps/qna/models/question_ai_answer.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from apps.core.models import TimeStampModel
 
-from .question import Question
+from apps.qna.models.question import Question
 
 
 class QuestionAIAnswer(TimeStampModel):

--- a/apps/qna/models/question_ai_answer.py
+++ b/apps/qna/models/question_ai_answer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import TimeStampModel
-
 from apps.qna.models.question import Question
 
 

--- a/apps/qna/models/question_image.py
+++ b/apps/qna/models/question_image.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import TimeStampModel
-
 from apps.qna.models.question import Question
 
 

--- a/apps/qna/models/question_image.py
+++ b/apps/qna/models/question_image.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from apps.core.models import TimeStampModel
 
-from .question import Question
+from apps.qna.models.question import Question
 
 
 class QuestionImage(TimeStampModel):

--- a/apps/qna/serializers/question_base.py
+++ b/apps/qna/serializers/question_base.py
@@ -1,5 +1,7 @@
 from typing import Any, cast
 
+from rest_framework import serializers
+
 from apps.qna.exceptions.question_exception import QuestionBaseException
 
 
@@ -12,5 +14,7 @@ class QnAVersionedValidationMixin:
         try:
             validated_data = super().validate(attrs)  # type: ignore
             return cast(dict[str, Any], validated_data)
-        except Exception as e:
+        except serializers.ValidationError as e:  # DRF 기본 ValidationError 발생 시
+            raise QuestionBaseException(detail=e.detail)
+        except Exception as e:  # 그 외 예상치 못한 에러
             raise QuestionBaseException(detail=f"데이터 처리 중 오류가 발생했습니다: {str(e)}")

--- a/apps/qna/serializers/question_base.py
+++ b/apps/qna/serializers/question_base.py
@@ -1,0 +1,16 @@
+from typing import Any, cast
+
+from apps.qna.exceptions.question_exception import QuestionBaseException
+
+
+class QnAVersionedValidationMixin:
+    """
+    QnA 시리얼라이저에서 공통적으로 사용할 예외 처리 로직을 담은 Mixin class
+    """
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:  # DRF의 내장 validate 로직에서 발생하는 에러 캐치
+        try:
+            validated_data = super().validate(attrs)  # type: ignore
+            return cast(dict[str, Any], validated_data)
+        except Exception as e:
+            raise QuestionBaseException(detail=f"데이터 처리 중 오류가 발생했습니다: {str(e)}")

--- a/apps/qna/serializers/question_serializer.py
+++ b/apps/qna/serializers/question_serializer.py
@@ -8,13 +8,10 @@ from apps.qna.serializers.question_base import QnAVersionedValidationMixin
 
 class QuestionCreateSerializer(QnAVersionedValidationMixin, serializers.ModelSerializer[Question]):
     category_id = serializers.IntegerField(required=True, help_text="카테고리 ID (소분류)")
-    image_ids = serializers.ListField(
-        child=serializers.IntegerField(), required=False, write_only=True, help_text="첨부할 이미지 PK 리스트"
-    )
 
     class Meta:
         model = Question
-        fields = ["title", "content", "category_id", "image_ids"]
+        fields = ["title", "content", "category_id"]
 
 
 class QuestionCreateResponseSerializer(QnAVersionedValidationMixin, serializers.Serializer[Any]):

--- a/apps/qna/serializers/question_serializer.py
+++ b/apps/qna/serializers/question_serializer.py
@@ -1,0 +1,22 @@
+from typing import Any, cast
+
+from rest_framework import serializers
+
+from apps.qna.models import Question
+from apps.qna.serializers.question_base import QnAVersionedValidationMixin
+
+
+class QuestionCreateSerializer(QnAVersionedValidationMixin, serializers.ModelSerializer[Question]):
+    category_id = serializers.IntegerField(required=True, help_text="카테고리 ID (소분류)")
+    image_ids = serializers.ListField(
+        child=serializers.IntegerField(), required=False, write_only=True, help_text="첨부할 이미지 PK 리스트"
+    )
+
+    class Meta:
+        model = Question
+        fields = ["title", "content", "category_id", "image_ids"]
+
+
+class QuestionCreateResponseSerializer(QnAVersionedValidationMixin, serializers.Serializer[Any]):
+    message = serializers.CharField(default="질문이 성공적으로 등록되었습니다.")
+    question_id = serializers.IntegerField(source="id")

--- a/apps/qna/services/question_service.py
+++ b/apps/qna/services/question_service.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from django.db import transaction
+
+from apps.qna.exceptions.question_exception import QuestionBaseException
+from apps.qna.models import Question, QuestionCategory, QuestionImage
+
+
+class QuestionService:
+    @staticmethod
+    @transaction.atomic
+    def create_question(author: Any, data: dict[str, Any]) -> Question:
+        """
+        질문 생성 및 리소스 연결 로직
+        """
+        try:
+            category_id = data.pop("category_id")
+            image_ids = data.pop("image_ids", [])
+
+            # 카테고리 획득
+            category = QuestionCategory.objects.get(id=category_id)
+
+            # 질문 생성
+            question = Question.objects.create(author=author, category=category, **data)
+
+            # 이미지 연관 관계 업데이트
+            if image_ids:
+                QuestionImage.objects.filter(id__in=image_ids, question__isnull=True).update(question=question)
+
+            return question
+
+        except Exception as e:
+            # 발생하는 모든 예외를 최상위 예외인 QuestionBaseException으로 전환합니다.
+            raise QuestionBaseException(detail=f"질문 등록 중 오류가 발생했습니다: {str(e)}")

--- a/apps/qna/services/question_service.py
+++ b/apps/qna/services/question_service.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.db import transaction
 
 from apps.qna.exceptions.question_exception import QuestionBaseException
-from apps.qna.models import Question, QuestionCategory, QuestionImage
+from apps.qna.models import Question, QuestionCategory
 
 
 class QuestionService:
@@ -11,21 +11,16 @@ class QuestionService:
     @transaction.atomic
     def create_question(author: Any, data: dict[str, Any]) -> Question:
         """
-        질문 생성 및 리소스 연결 로직
+        질문 생성 로직
         """
         try:
             category_id = data.pop("category_id")
-            image_ids = data.pop("image_ids", [])
 
             # 카테고리 획득
             category = QuestionCategory.objects.get(id=category_id)
 
             # 질문 생성
             question = Question.objects.create(author=author, category=category, **data)
-
-            # 이미지 연관 관계 업데이트
-            if image_ids:
-                QuestionImage.objects.filter(id__in=image_ids, question__isnull=True).update(question=question)
 
             return question
 

--- a/apps/qna/tests/test_question_create.py
+++ b/apps/qna/tests/test_question_create.py
@@ -1,0 +1,145 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from rest_framework import status
+
+from apps.qna.models import Question, QuestionCategory, QuestionImage
+
+User = get_user_model()
+
+
+class QuestionCreateAPITest(TestCase):
+    """
+    질문 등록 API 테스트
+    """
+
+    def setUp(self) -> None:
+        # 테스트용 클라이언트 초기화
+        self.client = Client()
+
+        # 테스트용 카테고리 생성
+        self.category = QuestionCategory.objects.create(name="Python")
+
+        # 테스트용 유저 생성 (수강생)
+        # birthday 필드 누락으로 인한 IntegrityError 방지를 위해 생년월일 포함
+        self.student_user = User.objects.create_user(
+            email="student@ozcoding.com",
+            password="password123",
+            nickname="수강생",
+            role="student",
+            birthday="1990-01-01",
+        )
+
+        # 테스트용 유저 생성 (일반인/권한 없음)
+        self.general_user = User.objects.create_user(
+            email="general@ozcoding.com",
+            password="password123",
+            nickname="일반인",
+            role="general",
+            birthday="1995-05-05",
+        )
+
+        # 이미지 제약 조건(NOT NULL) 우회를 위한 더미 질문 생성
+        self.dummy_question = Question.objects.create(
+            author=self.student_user,
+            category=self.category,
+            title="더미",
+            content="내용",
+        )
+
+        # URL 설정 이름 확인
+        self.url = reverse("question-create")
+
+    def test_create_question_success(self) -> None:
+        """
+        [성공] 수강생 권한으로 유효한 데이터를 전송하면 질문이 등록되어야 함
+        """
+        self.client.force_login(self.student_user)
+
+        data = {
+            "title": "장고 질문입니다.",
+            "content": "이 에러는 어떻게 해결하나요?",
+            "category_id": self.category.id,
+        }
+
+        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["message"], "질문이 성공적으로 등록되었습니다.")
+
+    def test_create_question_with_images_success(self) -> None:
+        """
+        [성공] 이미지 PK를 포함하여 질문을 등록하면 연관 관계가 업데이트되어야 함
+        """
+        self.client.force_login(self.student_user)
+
+        # QuestionImage 모델의 question 필드 NOT NULL 제약조건 해결
+        img1 = QuestionImage.objects.create(question=self.dummy_question)
+        img2 = QuestionImage.objects.create(question=self.dummy_question)
+
+        data = {
+            "title": "이미지 포함 질문",
+            "content": "이미지 테스트입니다.",
+            "category_id": self.category.id,
+            "image_ids": [img1.id, img2.id],
+        }
+
+        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        img1.refresh_from_db()
+        self.assertIsNotNone(img1.question)
+
+    def test_create_question_unauthorized(self) -> None:
+        """
+        [실패] 로그인하지 않은 경우 401 에러를 반환해야 함
+        """
+        data = {"title": "비회원 질문", "content": "내용", "category_id": self.category.id}
+
+        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_question_forbidden(self) -> None:
+        """
+        [실패] 수강생이 아닌 유저가 요청하면 403 에러를 반환해야 함
+        """
+        self.client.force_login(self.general_user)
+
+        data = {"title": "일반인 질문", "content": "내용", "category_id": self.category.id}
+
+        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_question_invalid_category(self) -> None:
+        """
+        [실패] 존재하지 않는 카테고리 ID 전송 시 400 에러 발생 확인
+        """
+        self.client.force_login(self.student_user)
+
+        data = {"title": "에러 질문", "content": "내용", "category_id": 9999}
+
+        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # 서비스 레이어 혹은 Mixin의 validate에서 발생한 에러는 'detail' 키에 담깁니다.
+        self.assertIn("detail", response.json())
+
+    def test_create_question_bad_request(self) -> None:
+        """
+        [실패] 필수 데이터 누락 시 400 에러 발생 확인
+        """
+        self.client.force_login(self.student_user)
+
+        # 필수 필드인 title 누락
+        data = {"content": "제목이 없어요", "category_id": self.category.id}
+
+        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # 필드 레벨 검증 실패 시 DRF는 해당 필드명을 키로 에러를 반환하므로 detail 키가 없을 수 있습니다.
+        # 따라서 응답에 에러 정보가 포함되어 있는지 확인합니다.
+        self.assertTrue(len(response.json()) > 0)

--- a/apps/qna/tests/test_question_create.py
+++ b/apps/qna/tests/test_question_create.py
@@ -1,11 +1,13 @@
 import json
+from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
 
-from apps.qna.models import Question, QuestionCategory, QuestionImage
+from apps.qna.models import QuestionCategory
 
 User = get_user_model()
 
@@ -16,47 +18,51 @@ class QuestionCreateAPITest(TestCase):
     """
 
     def setUp(self) -> None:
-        # 테스트용 클라이언트 초기화
+        # Django 내장 TestClient 초기화
         self.client = Client()
 
         # 테스트용 카테고리 생성
-        self.category = QuestionCategory.objects.create(name="Python")
+        self.category = QuestionCategory.objects.create(name="OZ_category")
 
         # 테스트용 유저 생성 (수강생)
-        # birthday 필드 누락으로 인한 IntegrityError 방지를 위해 생년월일 포함
         self.student_user = User.objects.create_user(
             email="student@ozcoding.com",
             password="password123",
+            name="test1",
             nickname="수강생",
-            role="student",
+            role="STUDENT",
             birthday="1990-01-01",
+            is_active=True,
         )
 
         # 테스트용 유저 생성 (일반인/권한 없음)
         self.general_user = User.objects.create_user(
             email="general@ozcoding.com",
             password="password123",
-            nickname="일반인",
-            role="general",
+            name="test2",
+            nickname="일반유저",
+            role="USER",
             birthday="1995-05-05",
-        )
-
-        # 이미지 제약 조건(NOT NULL) 우회를 위한 더미 질문 생성
-        self.dummy_question = Question.objects.create(
-            author=self.student_user,
-            category=self.category,
-            title="더미",
-            content="내용",
+            is_active=True,
         )
 
         # URL 설정 이름 확인
         self.url = reverse("question-create")
 
+    def _get_auth_header(self, user: Any) -> dict[str, Any]:
+        """
+        유저 객체를 받아 JWT 액세스 토큰을 생성하고,
+        Django Client가 인식할 수 있는 HTTP_AUTHORIZATION 헤더 딕셔너리를 반환합니다.
+        반환 타입을 dict[str, Any]로 변경하여 mypy 호환성을 높입니다.
+        """
+        refresh = RefreshToken.for_user(user)
+        return {"HTTP_AUTHORIZATION": f"Bearer {str(refresh.access_token)}"}
+
     def test_create_question_success(self) -> None:
         """
         [성공] 수강생 권한으로 유효한 데이터를 전송하면 질문이 등록되어야 함
         """
-        self.client.force_login(self.student_user)
+        auth_header = self._get_auth_header(self.student_user)
 
         data = {
             "title": "장고 질문입니다.",
@@ -64,37 +70,16 @@ class QuestionCreateAPITest(TestCase):
             "category_id": self.category.id,
         }
 
-        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+        response = self.client.post(
+            self.url, data=json.dumps(data), content_type="application/json", secure=False, **auth_header
+        )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["message"], "질문이 성공적으로 등록되었습니다.")
 
-    def test_create_question_with_images_success(self) -> None:
-        """
-        [성공] 이미지 PK를 포함하여 질문을 등록하면 연관 관계가 업데이트되어야 함
-        """
-        self.client.force_login(self.student_user)
-
-        # QuestionImage 모델의 question 필드 NOT NULL 제약조건 해결
-        img1 = QuestionImage.objects.create(question=self.dummy_question)
-        img2 = QuestionImage.objects.create(question=self.dummy_question)
-
-        data = {
-            "title": "이미지 포함 질문",
-            "content": "이미지 테스트입니다.",
-            "category_id": self.category.id,
-            "image_ids": [img1.id, img2.id],
-        }
-
-        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        img1.refresh_from_db()
-        self.assertIsNotNone(img1.question)
-
     def test_create_question_unauthorized(self) -> None:
         """
-        [실패] 로그인하지 않은 경우 401 에러를 반환해야 함
+        [실패] 로그인하지 않은 경우 (토큰이 없는 경우) 401 에러를 반환해야 함
         """
         data = {"title": "비회원 질문", "content": "내용", "category_id": self.category.id}
 
@@ -106,11 +91,13 @@ class QuestionCreateAPITest(TestCase):
         """
         [실패] 수강생이 아닌 유저가 요청하면 403 에러를 반환해야 함
         """
-        self.client.force_login(self.general_user)
+        auth_header = self._get_auth_header(self.general_user)
 
         data = {"title": "일반인 질문", "content": "내용", "category_id": self.category.id}
 
-        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+        response = self.client.post(
+            self.url, data=json.dumps(data), content_type="application/json", secure=False, **auth_header
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -118,28 +105,29 @@ class QuestionCreateAPITest(TestCase):
         """
         [실패] 존재하지 않는 카테고리 ID 전송 시 400 에러 발생 확인
         """
-        self.client.force_login(self.student_user)
+        auth_header = self._get_auth_header(self.student_user)
 
         data = {"title": "에러 질문", "content": "내용", "category_id": 9999}
 
-        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+        response = self.client.post(
+            self.url, data=json.dumps(data), content_type="application/json", secure=False, **auth_header
+        )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        # 서비스 레이어 혹은 Mixin의 validate에서 발생한 에러는 'detail' 키에 담깁니다.
-        self.assertIn("detail", response.json())
+        self.assertIn("질문 등록 중 오류가 발생했습니다", response.json()["detail"])
 
     def test_create_question_bad_request(self) -> None:
         """
         [실패] 필수 데이터 누락 시 400 에러 발생 확인
         """
-        self.client.force_login(self.student_user)
+        auth_header = self._get_auth_header(self.student_user)
 
         # 필수 필드인 title 누락
         data = {"content": "제목이 없어요", "category_id": self.category.id}
 
-        response = self.client.post(self.url, data=json.dumps(data), content_type="application/json")
+        response = self.client.post(
+            self.url, data=json.dumps(data), content_type="application/json", secure=False, **auth_header
+        )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        # 필드 레벨 검증 실패 시 DRF는 해당 필드명을 키로 에러를 반환하므로 detail 키가 없을 수 있습니다.
-        # 따라서 응답에 에러 정보가 포함되어 있는지 확인합니다.
         self.assertTrue(len(response.json()) > 0)

--- a/apps/qna/urls/question_urls.py
+++ b/apps/qna/urls/question_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from apps.qna.views.question_view import QuestionCreateAPIView
+
+urlpatterns = [
+    # 엔드포인트는 동일하게 유지하되 APIView 클래스 연결
+    path("questions", QuestionCreateAPIView.as_view(), name="question-create"),
+]

--- a/apps/qna/utils/permissions.py
+++ b/apps/qna/utils/permissions.py
@@ -19,7 +19,7 @@ class IsStudent(BasePermission):
             raise QuestionAuthenticationRequiredException()
 
         user_role = getattr(request.user, "role", None)
-        if not user_role or str(user_role).lower() != "student":
+        if not user_role or str(user_role) != "STUDENT":
             raise QuestionPermissionDeniedException()
 
         return True  # user_role이 STUDENT일때 True

--- a/apps/qna/utils/permissions.py
+++ b/apps/qna/utils/permissions.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+
+from apps.qna.exceptions.question_exception import (
+    QuestionAuthenticationRequiredException,
+    QuestionPermissionDeniedException,
+)
+
+
+class IsStudent(BasePermission):
+    """
+    수강생 권한 검증
+    """
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        if not (request.user and request.user.is_authenticated):  # 로그인 여부 확인
+            raise QuestionAuthenticationRequiredException()
+
+        user_role = getattr(request.user, "role", None)
+        if not user_role or str(user_role).lower() != "student":
+            raise QuestionPermissionDeniedException()
+
+        return True  # user_role이 STUDENT일때 True

--- a/apps/qna/views/question_view.py
+++ b/apps/qna/views/question_view.py
@@ -1,0 +1,47 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.qna.serializers.question_serializer import (
+    QuestionCreateResponseSerializer,
+    QuestionCreateSerializer,
+)
+from apps.qna.services.question_service import QuestionService
+from apps.qna.utils.permissions import IsStudent
+
+
+# 질문 등록
+class QuestionCreateAPIView(APIView):
+    permission_classes = [IsStudent]  # 학생만 question 등록 가능
+
+    @extend_schema(
+        summary="질문 등록 API",
+        description=(
+            "수강생 권한을 가진 로그인 유저가 질문을 등록합니다.\n\n"
+            "질문 등록 시 입력 항목\n"
+            "- 제목: 질문의 핵심 요약\n"
+            "- 질문내용: 마크다운 문법 사용 가능, 이미지 첨부 가능\n"
+            "- 카테고리: 대분류 > 중분류 > 소분류\n"
+            "- 내용에 포함된 이미지들의 PK 리스트"
+        ),
+        request=QuestionCreateSerializer,
+        responses={
+            201: OpenApiResponse(response=QuestionCreateResponseSerializer, description="질문 등록 성공"),
+            400: OpenApiResponse(description="잘못된 요청 데이터 (Bad Request)"),
+            401: OpenApiResponse(description="인증 실패 (Unauthorized)"),
+            403: OpenApiResponse(description="접근 권한 없음 (Forbidden)"),
+        },
+        tags=["QnA"],
+    )
+    def post(self, request: Request) -> Response:
+        serializer = QuestionCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        # 서비스 호출
+        question = QuestionService.create_question(author=request.user, data=serializer.validated_data)
+
+        # 응답 출력
+        response_serializer = QuestionCreateResponseSerializer(question)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -12,7 +12,7 @@ if DEBUG:
 REST_FRAMEWORK.update(
     {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "rest_framework.authentication.SessionAuthentication", # 로컬에서 테스트 코드 동작시 force_login 작동을 위함
+            "rest_framework.authentication.SessionAuthentication",  # 로컬에서 테스트 코드 동작시 force_login 작동을 위함
             "rest_framework_simplejwt.authentication.JWTAuthentication",
         ),
     }

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -9,15 +9,6 @@ if DEBUG:
     INSTALLED_APPS += ["debug_toolbar"]
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 
-REST_FRAMEWORK.update(
-    {
-        "DEFAULT_AUTHENTICATION_CLASSES": (
-            "rest_framework.authentication.SessionAuthentication",  # 로컬에서 테스트 코드 동작시 force_login 작동을 위함
-            "rest_framework_simplejwt.authentication.JWTAuthentication",
-        ),
-    }
-)
-
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -9,6 +9,15 @@ if DEBUG:
     INSTALLED_APPS += ["debug_toolbar"]
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 
+REST_FRAMEWORK.update(
+    {
+        "DEFAULT_AUTHENTICATION_CLASSES": (
+            "rest_framework.authentication.SessionAuthentication", # 로컬에서 테스트 코드 동작시 force_login 작동을 위함
+            "rest_framework_simplejwt.authentication.JWTAuthentication",
+        ),
+    }
+)
+
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/accounts/", include("apps.users.urls")),
     path("api/v1/admin/", include("apps.exams.admin_urls")),
     path("api/v1/exams/", include("apps.exams.urls")),
+    path("api/v1/qna/", include("apps.qna.urls.question_urls")),
 ]
 
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 질문 생성 API 구현 및 테스트 코드 생성

## 📄 상세 내용
- [x] 유저 roll이 STUDENT일때  질문을 등록할 수 있는 기능 구현
- [x] 로그인 되지 않은 유저, STUDENT가 아닌유저, 그 외 400 에러를 커스텀 예외코드로 분리 구현 
- [x] 질문 등록 API 엔드포인트 연결
- [x] Django 내장 TestClient를 활용하여 질문 등록 API의 다양한 케이스 검증
- [x] 로컬의 테스트 환경에서 Django Client의 force_login이 생성하는 세션 정보를 DRF API 레이어에서 인식할 수 있도록 config/settings/local.py 수정
- [x] models의 import 상대경로 -> 절대경로로 변경 

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
