### PR TITLE
[feature/admin-exam-delete] ✨ feat: 관리자 쪽지시험 삭제 API 및 테스트 추가

### DIFF
--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 
-from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
+from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 
 urlpatterns = [
     path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
-    path("<int:exam_id>/", AdminExamDeleteAPIView.as_view(), name="admin-exam-delete"),
+    path("exams/<int:exam_id>/", AdminExamDeleteAPIView.as_view(), name="admin-exam-delete"),
     path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
 ]

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
+from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 
 urlpatterns = [
     path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
+    path("<int:exam_id>/", AdminExamDeleteAPIView.as_view(), name="admin-exam-delete"),
     path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
 ]

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -32,3 +32,21 @@ class IsExamStaff(BasePermission):
             User.Role.LC,
             User.Role.OM,
         }
+
+
+class IsExamDeleteStaff(BasePermission):
+    message = "쪽지시험 삭제 권한이 없습니다."
+
+    def has_permission(self, request: Any, view: Any) -> bool:
+        user = request.user
+        return bool(
+            user
+            and user.is_authenticated
+            and user.role
+            in {
+                User.Role.ADMIN,
+                User.Role.TA,
+                User.Role.LC,
+                User.Role.OM,
+            }
+        )

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -20,7 +20,7 @@ class IsStudentRole(BasePermission):
 class IsExamStaff(BasePermission):
     """쪽지시험 관리자 API용 권한 검사."""
 
-    message = "쪽지시험 문제 등록 권한이 없습니다."
+    message = "쪽지시험 관리 권한이 없습니다."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
         user = request.user
@@ -32,21 +32,3 @@ class IsExamStaff(BasePermission):
             User.Role.LC,
             User.Role.OM,
         }
-
-
-class IsExamDeleteStaff(BasePermission):
-    message = "쪽지시험 삭제 권한이 없습니다."
-
-    def has_permission(self, request: Any, view: Any) -> bool:
-        user = request.user
-        return bool(
-            user
-            and user.is_authenticated
-            and user.role
-            in {
-                User.Role.ADMIN,
-                User.Role.TA,
-                User.Role.LC,
-                User.Role.OM,
-            }
-        )

--- a/apps/exams/serializers/admin_exam_delete_serializers.py
+++ b/apps/exams/serializers/admin_exam_delete_serializers.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamDeleteResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 삭제 응답 스키마."""
+
+    id = serializers.IntegerField()

--- a/apps/exams/services/admin_exam_delete_service.py
+++ b/apps/exams/services/admin_exam_delete_service.py
@@ -1,0 +1,26 @@
+from django.db import transaction
+
+from apps.exams.models import Exam
+
+
+class ExamDeleteNotFoundError(Exception):
+    """삭제 대상 쪽지시험을 찾지 못했을 때 발생."""
+
+
+class ExamDeleteConflictError(Exception):
+    """쪽지시험 삭제 중 충돌 발생 시."""
+
+
+def delete_exam(exam_id: int) -> int:
+    try:
+        exam = Exam.objects.get(id=exam_id)
+    except Exam.DoesNotExist as exc:
+        raise ExamDeleteNotFoundError from exc
+
+    try:
+        with transaction.atomic():
+            exam.delete()
+    except Exception as exc:
+        raise ExamDeleteConflictError from exc
+
+    return exam_id

--- a/apps/exams/tests/test_admin_exam_delete_views.py
+++ b/apps/exams/tests/test_admin_exam_delete_views.py
@@ -1,0 +1,123 @@
+from datetime import date, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion
+from apps.users.models import User
+
+
+class AdminExamDeleteAPITest(TestCase):
+    """어드민 쪽지시험 삭제 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.deployment = ExamDeployment.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE",
+            open_at=timezone.now(),
+            close_at=timezone.now() + timedelta(days=1),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        self.question = ExamQuestion.objects.create(
+            exam=self.exam,
+            question="OX 문제",
+            type=ExamQuestion.TypeChoices.OX,
+            answer="O",
+            point=5,
+            explanation="",
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_delete_exam(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/exams/{self.exam.id}/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["id"], self.exam.id)
+        self.assertFalse(Exam.objects.filter(id=self.exam.id).exists())
+        self.assertFalse(ExamQuestion.objects.filter(id=self.question.id).exists())
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.delete(f"/api/v1/admin/exams/{self.exam.id}/")
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_returns_403_for_non_staff(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/exams/{self.exam.id}/",
+            headers=self._auth_headers(self.normal_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["detail"], "쪽지시험 삭제 권한이 없습니다.")
+
+    def test_returns_404_when_exam_missing(self) -> None:
+        response = self.client.delete(
+            "/api/v1/admin/exams/9999/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "삭제하려는 쪽지시험 정보를 찾을 수 없습니다.")

--- a/apps/exams/tests/test_admin_question_views.py
+++ b/apps/exams/tests/test_admin_question_views.py
@@ -151,7 +151,7 @@ class AdminExamQuestionCreateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         data = response.json()
-        self.assertEqual(data["detail"], "쪽지시험 문제 등록 권한이 없습니다.")
+        self.assertEqual(data["detail"], "쪽지시험 관리 권한이 없습니다.")
 
     def test_returns_404_when_exam_missing(self) -> None:
         payload = {

--- a/apps/exams/views/admin_exam_delete_views.py
+++ b/apps/exams/views/admin_exam_delete_views.py
@@ -1,0 +1,64 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.permissions import IsExamDeleteStaff
+from apps.exams.serializers.admin_exam_delete_serializers import (
+    AdminExamDeleteResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin_exam_delete_service import (
+    ExamDeleteConflictError,
+    ExamDeleteNotFoundError,
+    delete_exam,
+)
+
+
+class AdminExamDeleteAPIView(APIView):
+    """어드민 쪽지시험 삭제 API."""
+
+    permission_classes = [IsAuthenticated, IsExamDeleteStaff]
+    serializer_class = AdminExamDeleteResponseSerializer
+
+    @extend_schema(
+        tags=["관리자-쪽지시험"],
+        summary="어드민 쪽지시험 삭제 API",
+        description="""
+        스태프/관리자가 쪽지시험을 삭제합니다.
+        삭제 시 등록된 문제들도 함께 제거됩니다.
+        """,
+        responses={
+            201: AdminExamDeleteResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="삭제 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="시험 정보 없음"),
+            409: OpenApiResponse(ErrorResponseSerializer, description="삭제 충돌"),
+        },
+    )
+    def delete(self, request: Request, exam_id: int) -> Response:
+        if exam_id <= 0:
+            return Response(
+                {"error_detail": "유효하지 않은 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            deleted_id = delete_exam(exam_id)
+        except ExamDeleteNotFoundError:
+            return Response(
+                {"error_detail": "삭제하려는 쪽지시험 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ExamDeleteConflictError:
+            return Response(
+                {"error_detail": "쪽지시험 삭제 중 충돌이 발생했습니다."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        serializer = self.serializer_class(data={"id": deleted_id})
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin_exam_delete_views.py
+++ b/apps/exams/views/admin_exam_delete_views.py
@@ -24,7 +24,7 @@ class AdminExamDeleteAPIView(APIView):
     serializer_class = AdminExamDeleteResponseSerializer
 
     @extend_schema(
-        tags=["관리자-쪽지시험"],
+        tags=["admin_exams"],
         summary="어드민 쪽지시험 삭제 API",
         description="""
         스태프/관리자가 쪽지시험을 삭제합니다.


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 관리자 쪽지시험 삭제 API 구현 및 테스트 추가

## 📄 상세 내용
- [x] `apps/exams/views/admin_exam_delete_views.py` `AdminExamDeleteAPIView` 추가 (삭제 처리/응답)
- [x] `apps/exams/services/admin_exam_delete_service.py` `delete_exam` 추가 (삭제 트랜잭션 처리)
- [x] `apps/exams/serializers/admin_exam_delete_serializers.py` `AdminExamDeleteResponseSerializer` 추가
- [x] `apps/exams/permissions.py` `IsExamDeleteStaff` 권한 클래스 추가
- [x] `apps/exams/admin_urls.py` 삭제 엔드포인트 등록
- [x] `apps/exams/tests/test_admin_exam_delete_views.py` `AdminExamDeleteAPITest` 추가


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
