### PR TITLE
[Feature/admin exam question delete] ✨ feat: 관리자 쪽지시험 문제 삭제 API 및 테스트 추가

### DIFF
--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
+from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin_submission_views import AdminExamSubmissionListAPIView
@@ -10,4 +11,9 @@ urlpatterns = [
     path("exams/<int:exam_id>/", AdminExamDeleteAPIView.as_view(), name="admin-exam-delete"),
     path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
     path("submissions/", AdminExamSubmissionListAPIView.as_view(), name="admin-exam-submission-list"),
+    path(
+        "exams/<int:exam_id>/questions/<int:question_id>/",
+        AdminExamQuestionDeleteAPIView.as_view(),
+        name="admin-exam-question-delete",
+    ),
 ]

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -11,8 +11,9 @@ urlpatterns = [
     path("exams/<int:exam_id>/", AdminExamDeleteAPIView.as_view(), name="admin-exam-delete"),
     path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
     path("submissions/", AdminExamSubmissionListAPIView.as_view(), name="admin-exam-submission-list"),
+    path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
     path(
-        "exams/<int:exam_id>/questions/<int:question_id>/",
+        "exams/questions/<int:question_id>/",
         AdminExamQuestionDeleteAPIView.as_view(),
         name="admin-exam-question-delete",
     ),

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 
 from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
-from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
+from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin_submission_views import AdminExamSubmissionListAPIView
 
@@ -11,7 +11,6 @@ urlpatterns = [
     path("exams/<int:exam_id>/", AdminExamDeleteAPIView.as_view(), name="admin-exam-delete"),
     path("exams", AdminExamCreateAPIView.as_view(), name="admin-exam-create"),
     path("submissions/", AdminExamSubmissionListAPIView.as_view(), name="admin-exam-submission-list"),
-    path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
     path(
         "exams/questions/<int:question_id>/",
         AdminExamQuestionDeleteAPIView.as_view(),

--- a/apps/exams/permissions.py
+++ b/apps/exams/permissions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from rest_framework.permissions import BasePermission

--- a/apps/exams/serializers/admin_question_delete_serializers.py
+++ b/apps/exams/serializers/admin_question_delete_serializers.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamQuestionDeleteResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 문제 삭제 응답 스키마."""
+
+    exam_id = serializers.IntegerField()
+    question_id = serializers.IntegerField()

--- a/apps/exams/services/admin_question_delete_service.py
+++ b/apps/exams/services/admin_question_delete_service.py
@@ -11,8 +11,8 @@ class ExamQuestionDeleteConflictError(Exception):
     """문제 삭제 중 충돌 발생 시."""
 
 
-def delete_exam_question(exam_id: int, question_id: int) -> dict[str, int]:
-    question = ExamQuestion.objects.filter(id=question_id, exam_id=exam_id).first()
+def delete_exam_question(question_id: int) -> dict[str, int]:
+    question = ExamQuestion.objects.filter(id=question_id).first()
     if not question:
         raise ExamQuestionDeleteNotFoundError
 
@@ -22,4 +22,4 @@ def delete_exam_question(exam_id: int, question_id: int) -> dict[str, int]:
     except Exception as exc:
         raise ExamQuestionDeleteConflictError from exc
 
-    return {"exam_id": exam_id, "question_id": question_id}
+    return {"exam_id": question.exam_id, "question_id": question_id}

--- a/apps/exams/services/admin_question_delete_service.py
+++ b/apps/exams/services/admin_question_delete_service.py
@@ -1,0 +1,25 @@
+from django.db import transaction
+
+from apps.exams.models import ExamQuestion
+
+
+class ExamQuestionDeleteNotFoundError(Exception):
+    """삭제 대상 문제를 찾지 못했을 때 발생."""
+
+
+class ExamQuestionDeleteConflictError(Exception):
+    """문제 삭제 중 충돌 발생 시."""
+
+
+def delete_exam_question(exam_id: int, question_id: int) -> dict[str, int]:
+    question = ExamQuestion.objects.filter(id=question_id, exam_id=exam_id).first()
+    if not question:
+        raise ExamQuestionDeleteNotFoundError
+
+    try:
+        with transaction.atomic():
+            question.delete()
+    except Exception as exc:
+        raise ExamQuestionDeleteConflictError from exc
+
+    return {"exam_id": exam_id, "question_id": question_id}

--- a/apps/exams/tests/test_admin_question_delete_views.py
+++ b/apps/exams/tests/test_admin_question_delete_views.py
@@ -74,7 +74,7 @@ class AdminExamQuestionDeleteAPITest(TestCase):
 
     def test_admin_can_delete_question(self) -> None:
         response = self.client.delete(
-            f"/api/v1/admin/exams/{self.exam.id}/questions/{self.question.id}/",
+            f"/api/v1/admin/exams/questions/{self.question.id}/",
             headers=self._auth_headers(self.admin_user),
         )
 
@@ -85,7 +85,7 @@ class AdminExamQuestionDeleteAPITest(TestCase):
         self.assertFalse(ExamQuestion.objects.filter(id=self.question.id).exists())
 
     def test_returns_401_when_unauthenticated(self) -> None:
-        response = self.client.delete(f"/api/v1/admin/exams/{self.exam.id}/questions/{self.question.id}/")
+        response = self.client.delete(f"/api/v1/admin/exams/questions/{self.question.id}/")
 
         self.assertEqual(response.status_code, 401)
         data = response.json()
@@ -93,7 +93,7 @@ class AdminExamQuestionDeleteAPITest(TestCase):
 
     def test_returns_403_for_non_staff(self) -> None:
         response = self.client.delete(
-            f"/api/v1/admin/exams/{self.exam.id}/questions/{self.question.id}/",
+            f"/api/v1/admin/exams/questions/{self.question.id}/",
             headers=self._auth_headers(self.normal_user),
         )
 
@@ -103,7 +103,7 @@ class AdminExamQuestionDeleteAPITest(TestCase):
 
     def test_returns_404_when_question_missing(self) -> None:
         response = self.client.delete(
-            f"/api/v1/admin/exams/{self.exam.id}/questions/9999/",
+            "/api/v1/admin/exams/questions/9999/",
             headers=self._auth_headers(self.admin_user),
         )
 
@@ -113,7 +113,7 @@ class AdminExamQuestionDeleteAPITest(TestCase):
 
     def test_returns_400_when_invalid_ids(self) -> None:
         response = self.client.delete(
-            "/api/v1/admin/exams/0/questions/0/",
+            "/api/v1/admin/exams/questions/0/",
             headers=self._auth_headers(self.admin_user),
         )
 

--- a/apps/exams/tests/test_admin_question_delete_views.py
+++ b/apps/exams/tests/test_admin_question_delete_views.py
@@ -1,0 +1,122 @@
+from datetime import date, timedelta
+
+from django.test import TestCase
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamQuestion
+from apps.users.models import User
+
+
+class AdminExamQuestionDeleteAPITest(TestCase):
+    """어드민 쪽지시험 문제 삭제 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.question = ExamQuestion.objects.create(
+            exam=self.exam,
+            question="OX 문제",
+            type=ExamQuestion.TypeChoices.OX,
+            answer="O",
+            point=5,
+            explanation="",
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_delete_question(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/exams/{self.exam.id}/questions/{self.question.id}/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["exam_id"], self.exam.id)
+        self.assertEqual(data["question_id"], self.question.id)
+        self.assertFalse(ExamQuestion.objects.filter(id=self.question.id).exists())
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.delete(f"/api/v1/admin/exams/{self.exam.id}/questions/{self.question.id}/")
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_returns_403_for_non_staff(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/exams/{self.exam.id}/questions/{self.question.id}/",
+            headers=self._auth_headers(self.normal_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["detail"], "쪽지시험 문제 삭제 권한이 없습니다.")
+
+    def test_returns_404_when_question_missing(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/exams/{self.exam.id}/questions/9999/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "삭제할 문제 정보를 찾을 수 없습니다.")
+
+    def test_returns_400_when_invalid_ids(self) -> None:
+        response = self.client.delete(
+            "/api/v1/admin/exams/0/questions/0/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "유효하지 않은 문제 삭제 요청입니다.")

--- a/apps/exams/views/admin_question_delete_views.py
+++ b/apps/exams/views/admin_question_delete_views.py
@@ -24,7 +24,7 @@ class AdminExamQuestionDeleteAPIView(APIView):
     serializer_class = AdminExamQuestionDeleteResponseSerializer
 
     @extend_schema(
-        tags=["관리자-쪽지시험"],
+        tags=["admin_exams"],
         summary="어드민 쪽지시험 문제 삭제 API",
         description="""
         스태프/관리자가 쪽지시험 문제를 삭제합니다.

--- a/apps/exams/views/admin_question_delete_views.py
+++ b/apps/exams/views/admin_question_delete_views.py
@@ -1,0 +1,79 @@
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.permissions import IsExamQuestionDeleteStaff
+from apps.exams.serializers.admin_question_delete_serializers import (
+    AdminExamQuestionDeleteResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin_question_delete_service import (
+    ExamQuestionDeleteConflictError,
+    ExamQuestionDeleteNotFoundError,
+    delete_exam_question,
+)
+
+
+class AdminExamQuestionDeleteAPIView(APIView):
+    """어드민 쪽지시험 문제 삭제 API."""
+
+    permission_classes = [IsAuthenticated, IsExamQuestionDeleteStaff]
+    serializer_class = AdminExamQuestionDeleteResponseSerializer
+
+    @extend_schema(
+        tags=["관리자-쪽지시험"],
+        summary="어드민 쪽지시험 문제 삭제 API",
+        description="""
+        스태프/관리자가 쪽지시험 문제를 삭제합니다.
+        """,
+        parameters=[
+            OpenApiParameter(
+                name="exam_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description="쪽지시험 ID",
+            ),
+            OpenApiParameter(
+                name="question_id",
+                type=int,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description="문제 ID",
+            ),
+        ],
+        responses={
+            200: AdminExamQuestionDeleteResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="문제 삭제 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="문제 정보 없음"),
+            409: OpenApiResponse(ErrorResponseSerializer, description="삭제 충돌"),
+        },
+    )
+    def delete(self, request: Request, exam_id: int, question_id: int) -> Response:
+        if exam_id <= 0 or question_id <= 0:
+            return Response(
+                {"error_detail": "유효하지 않은 문제 삭제 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            result = delete_exam_question(exam_id, question_id)
+        except ExamQuestionDeleteNotFoundError:
+            return Response(
+                {"error_detail": "삭제할 문제 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ExamQuestionDeleteConflictError:
+            return Response(
+                {"error_detail": "쪽지시험 문제 삭제 처리 중 충돌이 발생했습니다."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        serializer = self.serializer_class(data=result)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 관리자 쪽지시험 문제 삭제 API 구현 및 테스트 추가

## 📄 상세 내용
- [x] `apps/exams/views/admin_question_delete_views.py` `AdminExamQuestionDeleteAPIView` 추가
- [x] `apps/exams/services/admin_question_delete_service.py` `delete_exam_question` 추가
- [x] `apps/exams/serializers/admin_question_delete_serializers.py` `AdminExamQuestionDeleteResponseSerializer` 추가
- [x] `apps/exams/permissions.py` `IsExamQuestionDeleteStaff` 권한 클래스 추가
- [x] `apps/exams/admin_urls.py` 삭제 엔드포인트 등록
- [x] `apps/exams/tests/test_admin_question_delete_views.py` `AdminExamQuestionDeleteAPITest` 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
