### PR TITLE
[Feature/admin exam deployment create] ✨ feat: 관리자 쪽지시험 배포 생성 API 및 테스트 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ dmypy-reset:
 	poetry run dmypy stop || true
 	rm -f .dmypy.json
 
-push-force:
+push-f:
 	@if [ -n "$(ARGS)" ]; then \
-		git push origin $(ARGS) --force-with-lease; \
+		git push origin $(ARGS) --force; \
 	else \
-		git push --force-with-lease; \
+		git push --force; \
 	fi
 
 fetch:
@@ -139,9 +139,9 @@ sync-develop:
 	@echo "---현재 브랜치는 develop 입니다"
 	@echo "🚨 🚨 🚨 🚨 🚨 작업할 브랜치로 이동하세요🚨 🚨 🚨 🚨 🚨"
 
-rebase-develop:
+rebase:
 	git fetch origin
-	git rebase origin/develop
+	git rebase develop
 
 %:
 	@:

--- a/README.md
+++ b/README.md
@@ -16,27 +16,27 @@ make logs django # Docker django service 로그만 확인
 - Local 환경 커맨드
    - `make run` - Django 개발 서버 실행
    - `make format` - 코드 포맷팅 실행 (black + isort + mypy)
-   - `make test [app_name]` - mypy 및 테스트를 커버리지와 함께 실행 [특정 앱 지정]
-   - `make makemigrations [app_name]` - 마이그레이션 생성 [특정 앱 지정]
-   - `make migrate [app_name]` - 마이그레이션 적용 [특정 앱 지정]
+   - `make test [app_name]` - mypy 및 테스트를 커버리지와 함께 실행 [특정 앱 지정 가능]
+   - `make makemigrations [app_name]` - 마이그레이션 생성 [특정 앱 지정 가능]
+   - `make migrate [app_name]` - 마이그레이션 적용 [특정 앱 지정 가능]
    - `make shell` - Django 셸 실행
    - `make dbshell` - 데이터베이스 셸 실행
 - Docker 환경 커맨드
-   - `make dtest [app_name|path]` - 컨테이너에서 테스트 & 커버리지 실행 [특정 앱 | 폴더 지정]
-   - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 생성 [특정 앱 지정]
-   - `make dmigrate [app_name]` - 컨테이너에서 마이그레이션 적용 [특정 앱 지정]
+   - `make dtest [app_name|path]` - 컨테이너에서 테스트 & 커버리지 실행 [특정 앱 | 폴더 지정 가능]
+   - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 생성 [특정 앱 지정 가능]
+   - `make dmigrate [app_name]` - 컨테이너에서 마이그레이션 적용 [특정 앱 지정 가능]
    - `make dshell` - 컨테이너에서 Django 셸 실행
    - `make ddbshell` - 컨테이너에서 데이터베이스 셸 실행
 - Docker 관리
-   - `make build [service_name]` - Docker 이미지 빌드 [특정 서비스 지정]
-   - `make up [service_name]` - Docker 서비스 시작 [특정 서비스 지정]
+   - `make build [service_name]` - Docker 이미지 빌드 [특정 서비스 지정 가능]
+   - `make up [service_name]` - Docker 서비스 시작 [특정 서비스 지정 가능]
    - `make down` - Docker 서비스 종료
    - `make restart` - Docker 서비스 재시작
-   - `make logs [service_name]` - Docker 로그 확인 [특정 서비스 지정]
+   - `make logs [service_name]` - Docker 로그 확인 [특정 서비스 지정 가능]
    - `make ps` - Docker 서비스 목록 확인
 - 기타 유틸리티
    - `make dmypy-reset` - dmypy 데몬 중지 및 캐시 삭제
-   - `make push-force [branch_name]` - 안전한 강제 푸시 실행 [특정 브랜치 지정]
+   - `make push-f [branch_name]` - 강제 푸시 실행 [특정 브랜치 지정 가능]
    - `make fetch` - 원격(origin) 최신 내역 가져오기
    - `make sync-develop` - 원격 최신 내역 가져오기 + develop 브랜치로 이동 + pull develop 브랜치
-   - `make rebase-develop` - origin/develop 기준으로 리베이스
+   - `make rebase` - 로컬 develop 기준으로 리베이스

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -5,6 +5,9 @@ from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin_submission_views import AdminExamSubmissionListAPIView
+from apps.exams.views.admin_exam_deployment_views import (
+    AdminExamDeploymentCreateAPIView,
+)
 
 urlpatterns = [
     path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),
@@ -16,4 +19,5 @@ urlpatterns = [
         AdminExamQuestionDeleteAPIView.as_view(),
         name="admin-exam-question-delete",
     ),
+    path("exams/deployments/", AdminExamDeploymentCreateAPIView.as_view(), name="admin-exam-deployment-create"),
 ]

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,13 +1,13 @@
 from django.urls import path
 
 from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
+from apps.exams.views.admin_exam_deployment_views import (
+    AdminExamDeploymentCreateAPIView,
+)
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin_submission_views import AdminExamSubmissionListAPIView
-from apps.exams.views.admin_exam_deployment_views import (
-    AdminExamDeploymentCreateAPIView,
-)
 
 urlpatterns = [
     path("exams/<int:exam_id>/questions/", AdminExamQuestionCreateAPIView.as_view(), name="admin-exam-question-create"),

--- a/apps/exams/serializers/admin_exam_deployment_serializers.py
+++ b/apps/exams/serializers/admin_exam_deployment_serializers.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamDeploymentCreateRequestSerializer(serializers.Serializer[Any]):
+    """쪽지시험 배포 생성 요청 스키마."""
+
+    exam_id = serializers.IntegerField()
+    cohort_id = serializers.IntegerField()
+    duration_time = serializers.IntegerField()
+    open_at = serializers.DateTimeField(input_formats=["%Y-%m-%d %H:%M:%S"])
+    close_at = serializers.DateTimeField(input_formats=["%Y-%m-%d %H:%M:%S"])
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        duration_time = attrs.get("duration_time")
+        if not isinstance(duration_time, int) or duration_time <= 0:
+            raise serializers.ValidationError("유효하지 않은 배포 생성 요청입니다.")
+
+        open_at = attrs.get("open_at")
+        close_at = attrs.get("close_at")
+        if open_at and close_at and open_at >= close_at:
+            raise serializers.ValidationError("유효하지 않은 배포 생성 요청입니다.")
+
+        return attrs
+
+
+class AdminExamDeploymentCreateResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 배포 생성 응답 스키마."""
+
+    pk = serializers.IntegerField()

--- a/apps/exams/services/admin_exam_deployment_service.py
+++ b/apps/exams/services/admin_exam_deployment_service.py
@@ -1,0 +1,86 @@
+import json
+from typing import Any
+from uuid import uuid4
+
+from django.db import transaction
+
+from apps.core.utils.base62 import Base62
+from apps.courses.models.cohorts import Cohort
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion
+
+
+class ExamDeploymentNotFoundError(Exception):
+    """배포 대상 정보를 찾지 못했을 때 발생."""
+
+
+class ExamDeploymentConflictError(Exception):
+    """배포 생성 중 중복/충돌 발생 시."""
+
+
+def _generate_access_code() -> str:
+    for _ in range(5):
+        code = Base62.uuid_encode(uuid4())
+        if not ExamDeployment.objects.filter(access_code=code).exists():
+            return code
+    return Base62.uuid_encode(uuid4(), length=8)
+
+
+def _build_question_snapshot(exam: Exam) -> list[dict[str, Any]]:
+    snapshot: list[dict[str, Any]] = []
+    questions = ExamQuestion.objects.filter(exam=exam).order_by("id")
+    for question in questions:
+        options = None
+        if question.options_json:
+            try:
+                options = json.loads(question.options_json)
+            except json.JSONDecodeError:
+                options = None
+
+        snapshot.append(
+            {
+                "question_id": question.id,
+                "type": question.type,
+                "question": question.question,
+                "prompt": question.prompt,
+                "blank_count": question.blank_count,
+                "options": options,
+                "point": question.point,
+            }
+        )
+    return snapshot
+
+
+def create_exam_deployment(payload: dict[str, Any]) -> int:
+    exam_id = payload["exam_id"]
+    cohort_id = payload["cohort_id"]
+    open_at = payload["open_at"]
+    close_at = payload["close_at"]
+    duration_time = payload["duration_time"]
+
+    exam = Exam.objects.filter(id=exam_id).first()
+    cohort = Cohort.objects.filter(id=cohort_id).first()
+    if not exam or not cohort:
+        raise ExamDeploymentNotFoundError
+
+    with transaction.atomic():
+        if ExamDeployment.objects.filter(
+            exam_id=exam_id,
+            cohort_id=cohort_id,
+            open_at=open_at,
+            close_at=close_at,
+        ).exists():
+            raise ExamDeploymentConflictError
+
+        snapshot = _build_question_snapshot(exam)
+        access_code = _generate_access_code()
+        deployment = ExamDeployment.objects.create(
+            exam=exam,
+            cohort=cohort,
+            duration_time=duration_time,
+            access_code=access_code,
+            open_at=open_at,
+            close_at=close_at,
+            questions_snapshot_json=snapshot,
+        )
+
+    return deployment.id

--- a/apps/exams/tests/test_admin_exam_deployment_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_views.py
@@ -1,0 +1,230 @@
+import json
+from datetime import date, datetime, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion
+from apps.users.models import User
+
+
+class AdminExamDeploymentCreateAPITest(TestCase):
+    """어드민 쪽지시험 배포 생성 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.question = ExamQuestion.objects.create(
+            exam=self.exam,
+            question="OX 문제",
+            type=ExamQuestion.TypeChoices.OX,
+            answer="O",
+            point=5,
+            explanation="",
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_create_deployment(self) -> None:
+        payload = {
+            "exam_id": self.exam.id,
+            "cohort_id": self.cohort.id,
+            "duration_time": 45,
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 12:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        deployment = ExamDeployment.objects.get(id=data["pk"])
+        self.assertEqual(deployment.exam_id, self.exam.id)
+        self.assertEqual(deployment.cohort_id, self.cohort.id)
+        self.assertEqual(deployment.duration_time, 45)
+        self.assertTrue(deployment.access_code)
+        self.assertIsInstance(deployment.questions_snapshot_json, list)
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        payload = {
+            "exam_id": self.exam.id,
+            "cohort_id": self.cohort.id,
+            "duration_time": 45,
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 12:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_returns_403_for_non_staff(self) -> None:
+        payload = {
+            "exam_id": self.exam.id,
+            "cohort_id": self.cohort.id,
+            "duration_time": 45,
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 12:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.normal_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["detail"], "쪽지시험 배포 생성 권한이 없습니다.")
+
+    def test_returns_404_when_exam_missing(self) -> None:
+        payload = {
+            "exam_id": 9999,
+            "cohort_id": self.cohort.id,
+            "duration_time": 45,
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 12:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "배포 대상 과정-기수 또는 시험 정보를 찾을 수 없습니다.")
+
+    def test_returns_404_when_cohort_missing(self) -> None:
+        payload = {
+            "exam_id": self.exam.id,
+            "cohort_id": 9999,
+            "duration_time": 45,
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 12:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "배포 대상 과정-기수 또는 시험 정보를 찾을 수 없습니다.")
+
+    def test_returns_409_when_duplicate_deployment(self) -> None:
+        open_at = timezone.make_aware(datetime(2025, 3, 2, 10, 0, 0))
+        close_at = timezone.make_aware(datetime(2025, 3, 2, 12, 0, 0))
+        ExamDeployment.objects.create(
+            exam=self.exam,
+            cohort=self.cohort,
+            duration_time=45,
+            access_code="CODE",
+            open_at=open_at,
+            close_at=close_at,
+            questions_snapshot_json=[],
+        )
+        payload = {
+            "exam_id": self.exam.id,
+            "cohort_id": self.cohort.id,
+            "duration_time": 45,
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 12:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 409)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "동일한 조건의 배포가 이미 존재합니다.")
+
+    def test_returns_400_when_invalid_payload(self) -> None:
+        payload = {
+            "exam_id": self.exam.id,
+            "cohort_id": self.cohort.id,
+            "duration_time": 0,
+            "open_at": "2025-03-02 12:00:00",
+            "close_at": "2025-03-02 10:00:00",
+        }
+
+        response = self.client.post(
+            "/api/v1/admin/exams/deployments/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "유효하지 않은 배포 생성 요청입니다.")

--- a/apps/exams/tests/test_admin_exam_deployment_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_views.py
@@ -136,7 +136,7 @@ class AdminExamDeploymentCreateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         data = response.json()
-        self.assertEqual(data["detail"], "쪽지시험 배포 생성 권한이 없습니다.")
+        self.assertEqual(data["detail"], "쪽지시험 관리 권한이 없습니다.")
 
     def test_returns_404_when_exam_missing(self) -> None:
         payload = {

--- a/apps/exams/views/admin_exam_deployment_views.py
+++ b/apps/exams/views/admin_exam_deployment_views.py
@@ -1,0 +1,67 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.permissions import IsExamDeploymentCreateStaff
+from apps.exams.serializers.admin_exam_deployment_serializers import (
+    AdminExamDeploymentCreateRequestSerializer,
+    AdminExamDeploymentCreateResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin_exam_deployment_service import (
+    ExamDeploymentConflictError,
+    ExamDeploymentNotFoundError,
+    create_exam_deployment,
+)
+
+
+class AdminExamDeploymentCreateAPIView(APIView):
+    """어드민 쪽지시험 배포 생성 API."""
+
+    permission_classes = [IsAuthenticated, IsExamDeploymentCreateStaff]
+    serializer_class = AdminExamDeploymentCreateRequestSerializer
+
+    @extend_schema(
+        tags=["admin_exams"],
+        summary="어드민 쪽지시험 배포 생성 API",
+        description="""
+        스태프/관리자가 쪽지시험 배포를 생성합니다.
+        배포 생성 시 문제 스냅샷과 참가 코드가 생성됩니다.
+        """,
+        request=AdminExamDeploymentCreateRequestSerializer,
+        responses={
+            201: AdminExamDeploymentCreateResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="배포 생성 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="배포 대상 정보 없음"),
+            409: OpenApiResponse(ErrorResponseSerializer, description="중복 배포"),
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = self.serializer_class(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"error_detail": "유효하지 않은 배포 생성 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            deployment_id = create_exam_deployment(serializer.validated_data)
+        except ExamDeploymentNotFoundError:
+            return Response(
+                {"error_detail": "배포 대상 과정-기수 또는 시험 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ExamDeploymentConflictError:
+            return Response(
+                {"error_detail": "동일한 조건의 배포가 이미 존재합니다."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        response_serializer = AdminExamDeploymentCreateResponseSerializer(data={"pk": deployment_id})
+        response_serializer.is_valid(raise_exception=True)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin_exam_deployment_views.py
+++ b/apps/exams/views/admin_exam_deployment_views.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.exams.permissions import IsExamDeploymentCreateStaff
+from apps.exams.permissions import IsExamStaff
 from apps.exams.serializers.admin_exam_deployment_serializers import (
     AdminExamDeploymentCreateRequestSerializer,
     AdminExamDeploymentCreateResponseSerializer,
@@ -21,7 +21,7 @@ from apps.exams.services.admin_exam_deployment_service import (
 class AdminExamDeploymentCreateAPIView(APIView):
     """어드민 쪽지시험 배포 생성 API."""
 
-    permission_classes = [IsAuthenticated, IsExamDeploymentCreateStaff]
+    permission_classes = [IsAuthenticated, IsExamStaff]
     serializer_class = AdminExamDeploymentCreateRequestSerializer
 
     @extend_schema(


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 관리자 쪽지시험 배포 생성 API 구현 및 테스트 추가

## 📄 상세 내용
- [x] `apps/exams/views/admin_exam_deployment_views.py` `AdminExamDeploymentCreateAPIView` 추가
- [x] `apps/exams/services/admin_exam_deployment_service.py` `create_exam_deployment` 추가 (스냅샷/참가코드 생성)
- [x] `apps/exams/serializers/admin_exam_deployment_serializers.py` 요청/응답 스키마 추가
- [x] `apps/exams/permissions.py` `IsExamDeploymentCreateStaff` 권한 클래스 추가
- [x] `apps/exams/admin_urls.py` 배포 생성 엔드포인트 등록
- [x] `apps/exams/tests/test_admin_exam_deployment_views.py` `AdminExamDeploymentCreateAPITest` 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
