### PR TITLE
[feature/admin-exam-deployment-toggle] ✨ feat: 관리자 쪽지시험 배포 상태 변경 API 및 테스트 추가

### DIFF
--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 
 from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
-from apps.exams.views.admin_exam_deployment_views import (
-    AdminExamDeploymentCreateAPIView,
-)
 from apps.exams.views.admin_exam_deployment_status_views import (
     AdminExamDeploymentStatusAPIView,
+)
+from apps.exams.views.admin_exam_deployment_views import (
+    AdminExamDeploymentCreateAPIView,
 )
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -4,6 +4,9 @@ from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
 from apps.exams.views.admin_exam_deployment_views import (
     AdminExamDeploymentCreateAPIView,
 )
+from apps.exams.views.admin_exam_deployment_status_views import (
+    AdminExamDeploymentStatusAPIView,
+)
 from apps.exams.views.admin_exam_views import AdminExamCreateAPIView
 from apps.exams.views.admin_question_delete_views import AdminExamQuestionDeleteAPIView
 from apps.exams.views.admin_question_views import AdminExamQuestionCreateAPIView
@@ -20,4 +23,9 @@ urlpatterns = [
         name="admin-exam-question-delete",
     ),
     path("exams/deployments/", AdminExamDeploymentCreateAPIView.as_view(), name="admin-exam-deployment-create"),
+    path(
+        "exams/deployments/<int:deployment_id>/status/",
+        AdminExamDeploymentStatusAPIView.as_view(),
+        name="admin-exam-deployment-status",
+    ),
 ]

--- a/apps/exams/serializers/admin_exam_deployment_status_serializers.py
+++ b/apps/exams/serializers/admin_exam_deployment_status_serializers.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamDeploymentStatusRequestSerializer(serializers.Serializer[Any]):
+    """쪽지시험 배포 상태 변경 요청 스키마."""
+
+    status = serializers.CharField()
+
+    def validate_status(self, value: str) -> str:
+        if value not in {"activated", "deactivated"}:
+            raise serializers.ValidationError("유효하지 않은 배포 상태 요청입니다.")
+        return value
+
+
+class AdminExamDeploymentStatusResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 배포 상태 변경 응답 스키마."""
+
+    deployment_id = serializers.IntegerField()
+    status = serializers.CharField()

--- a/apps/exams/services/admin_exam_deployment_status_service.py
+++ b/apps/exams/services/admin_exam_deployment_status_service.py
@@ -1,0 +1,34 @@
+from django.db import transaction
+
+from apps.exams.models import ExamDeployment
+
+
+class ExamDeploymentStatusNotFoundError(Exception):
+    """배포 정보를 찾지 못했을 때 발생."""
+
+
+class ExamDeploymentStatusConflictError(Exception):
+    """배포 상태 변경 중 충돌 발생 시."""
+
+
+def update_deployment_status(deployment_id: int, status: str) -> ExamDeployment:
+    try:
+        with transaction.atomic():
+            try:
+                deployment = ExamDeployment.objects.select_for_update().get(id=deployment_id)
+            except ExamDeployment.DoesNotExist as exc:
+                raise ExamDeploymentStatusNotFoundError from exc
+
+            new_status = (
+                ExamDeployment.StatusChoices.ACTIVATED
+                if status == "activated"
+                else ExamDeployment.StatusChoices.DEACTIVATED
+            )
+            deployment.status = new_status
+            deployment.save(update_fields=["status"])
+    except ExamDeploymentStatusNotFoundError:
+        raise
+    except Exception as exc:
+        raise ExamDeploymentStatusConflictError from exc
+
+    return deployment

--- a/apps/exams/tests/test_admin_exam_deployment_status_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_status_views.py
@@ -1,0 +1,149 @@
+import json
+from datetime import date, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment
+from apps.users.models import User
+
+
+class AdminExamDeploymentStatusAPITest(TestCase):
+    """어드민 쪽지시험 배포 상태 변경 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.deployment = ExamDeployment.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE",
+            open_at=timezone.now(),
+            close_at=timezone.now() + timedelta(hours=2),
+            questions_snapshot_json=[],
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_update_status(self) -> None:
+        payload = {"status": "deactivated"}
+
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/status/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["deployment_id"], self.deployment.id)
+        self.assertEqual(data["status"], "deactivated")
+        self.deployment.refresh_from_db()
+        self.assertEqual(self.deployment.status, ExamDeployment.StatusChoices.DEACTIVATED)
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        payload = {"status": "deactivated"}
+
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/status/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_returns_403_for_non_staff(self) -> None:
+        payload = {"status": "deactivated"}
+
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/status/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.normal_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["detail"], "쪽지시험 배포 상태 변경 권한이 없습니다.")
+
+    def test_returns_404_when_deployment_missing(self) -> None:
+        payload = {"status": "deactivated"}
+
+        response = self.client.patch(
+            "/api/v1/admin/exams/deployments/9999/status/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "해당 배포 정보를 찾을 수 없습니다.")
+
+    def test_returns_400_when_invalid_status(self) -> None:
+        payload = {"status": "invalid"}
+
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/status/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "유효하지 않은 배포 상태 요청입니다.")

--- a/apps/exams/views/admin_exam_deployment_status_views.py
+++ b/apps/exams/views/admin_exam_deployment_status_views.py
@@ -1,0 +1,78 @@
+from typing import NoReturn
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.permissions import IsExamStaff
+from apps.exams.serializers.admin_exam_deployment_status_serializers import (
+    AdminExamDeploymentStatusRequestSerializer,
+    AdminExamDeploymentStatusResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin_exam_deployment_status_service import (
+    ExamDeploymentStatusConflictError,
+    ExamDeploymentStatusNotFoundError,
+    update_deployment_status,
+)
+
+
+class AdminExamDeploymentStatusAPIView(APIView):
+    """어드민 쪽지시험 배포 상태 변경 API."""
+
+    permission_classes = [IsAuthenticated, IsExamStaff]
+    serializer_class = AdminExamDeploymentStatusRequestSerializer
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        if not request.user or not request.user.is_authenticated:
+            raise NotAuthenticated()
+        raise PermissionDenied(detail="쪽지시험 배포 상태 변경 권한이 없습니다.")
+
+    @extend_schema(
+        tags=["admin_exams"],
+        summary="어드민 쪽지시험 배포 상태 변경 API",
+        description="""
+        스태프/관리자가 쪽지시험 배포를 활성화/비활성화합니다.
+        """,
+        request=AdminExamDeploymentStatusRequestSerializer,
+        responses={
+            200: AdminExamDeploymentStatusResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="배포 상태 변경 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="배포 정보 없음"),
+            409: OpenApiResponse(ErrorResponseSerializer, description="상태 변경 충돌"),
+        },
+    )
+    def patch(self, request: Request, deployment_id: int) -> Response:
+        serializer = self.serializer_class(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"error_detail": "유효하지 않은 배포 상태 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            deployment = update_deployment_status(deployment_id, serializer.validated_data["status"])
+        except ExamDeploymentStatusNotFoundError:
+            return Response(
+                {"error_detail": "해당 배포 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ExamDeploymentStatusConflictError:
+            return Response(
+                {"error_detail": "배포 상태 변경 중 충돌이 발생했습니다."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        response_serializer = AdminExamDeploymentStatusResponseSerializer(
+            {
+                "deployment_id": deployment.id,
+                "status": serializer.validated_data["status"],
+            }
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 관리자 쪽지시험 배포 상태 변경 API 구현 및 테스트 추가

## 📄 상세 내용
- [x] `apps/exams/views/admin_exam_deployment_status_views.py` `AdminExamDeploymentStatusAPIView` 추가
- [x] `apps/exams/services/admin_exam_deployment_status_service.py` `update_deployment_status` 추가
- [x] `apps/exams/serializers/admin_exam_deployment_status_serializers.py` 요청/응답 스키마 추가
- [x] `apps/exams/admin_urls.py` 배포 상태 변경 엔드포인트 등록
- [x] `apps/exams/tests/test_admin_exam_deployment_status_views.py` `AdminExamDeploymentStatusAPITest` 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
