### PR TITLE
[feature/dev-setup] build: Makefile, test.sh에 인자 처리 기능 추가 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,42 +2,48 @@
 	up down restart logs ps build dtest dmypy-reset push-force fetch rebase-develop
 
 COMPOSE_FILE := docker-compose.local.yml
+ARGS = $(filter-out $@,$(MAKECMDGOALS))
 
 help:
 	@echo "Targets:"
+	@echo "  run              Run Django dev server"
 	@echo "  format           Run black + isort"
 	@echo "  test             Run mypy + tests with coverage"
-	@echo "  run              Run Django dev server"
 	@echo "  makemigrations   Create Django migrations"
 	@echo "  migrate          Apply Django migrations"
 	@echo "  shell            Django shell"
 	@echo "  dbshell          Django db shell"
+	@echo "  dtest            Run mypy + tests with coverage (Docker)"
+	@echo "  dmakemigrations  Create Django migrations (Docker)"
+	@echo "  dmigrate         Apply Django migrations (Docker)"
+	@echo "  dshell           Django shell (Docker)"
+	@echo "  ddbshell         Django db shell (Docker)"
 	@echo "  build            Build Docker images"
 	@echo "  up               Start Docker services"
 	@echo "  down             Stop Docker services"
 	@echo "  restart          Restart Docker services"
 	@echo "  logs             Tail Docker logs"
 	@echo "  ps               List Docker services"
-	@echo "  dtest            Run tests in Docker (exec django)"
 	@echo "  dmypy-reset      Stop dmypy and clear cache"
 	@echo "  push-force       Force push with lease"
 	@echo "  fetch            Fetch from origin"
+	@echo "  sync-develop     Fetch, checkout develop, and pull origin develop"
 	@echo "  rebase-develop   Rebase onto origin/develop"
+
+run:
+	python manage.py runserver
 
 format:
 	bash resources/scripts/code_formatting.sh
 
 test:
-	bash resources/scripts/test.sh
-
-run:
-	python manage.py runserver
+	bash resources/scripts/test.sh $(ARGS)
 
 makemigrations:
-	python manage.py makemigrations $(APP)
+	python manage.py makemigrations $(ARGS)
 
 migrate:
-	python manage.py migrate $(APP)
+	python manage.py migrate $(ARGS)
 
 shell:
 	python manage.py shell
@@ -45,11 +51,26 @@ shell:
 dbshell:
 	python manage.py dbshell
 
+dtest:
+	docker compose -f $(COMPOSE_FILE) exec django make test $(ARGS)
+
+dmakemigrations:
+	docker compose -f $(COMPOSE_FILE) exec django make makemigrations $(ARGS)
+
+dmigrate:
+	docker compose -f $(COMPOSE_FILE) exec django make migrate $(ARGS)
+
+dshell:
+	docker compose -f $(COMPOSE_FILE) exec django make shell
+
+ddbshell:
+	docker compose -f $(COMPOSE_FILE) exec django make dbshell
+
 build:
-	docker compose -f $(COMPOSE_FILE) build
+	docker compose -f $(COMPOSE_FILE) build $(ARGS)
 
 up:
-	docker compose -f $(COMPOSE_FILE) up -d
+	docker compose -f $(COMPOSE_FILE) up -d $(ARGS)
 
 down:
 	docker compose -f $(COMPOSE_FILE) down
@@ -58,13 +79,10 @@ restart:
 	docker compose -f $(COMPOSE_FILE) restart
 
 logs:
-	docker compose -f $(COMPOSE_FILE) logs -f --tail=100
+	docker compose -f $(COMPOSE_FILE) logs -f --tail=100 $(ARGS)
 
 ps:
 	docker compose -f $(COMPOSE_FILE) ps
-
-dtest:
-	docker compose -f $(COMPOSE_FILE) exec django make test
 
 dmypy-reset:
 	poetry run dmypy stop || true
@@ -76,6 +94,14 @@ push-force:
 fetch:
 	git fetch origin
 
+sync-develop:
+	git fetch origin
+	git checkout develop
+	git pull origin develop
+
 rebase-develop:
 	git fetch origin
 	git rebase origin/develop
+
+%:
+	@:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,11 @@ dmypy-reset:
 	rm -f .dmypy.json
 
 push-force:
-	git push --force-with-lease
+	@if [ -n "$(ARGS)" ]; then \
+		git push origin $(ARGS) --force-with-lease; \
+	else \
+		git push --force-with-lease; \
+	fi
 
 fetch:
 	git fetch origin

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo "  dmypy-reset      Stop dmypy and clear cache"
 	@echo "  push-force       Force push with lease"
 	@echo "  fetch            Fetch from origin"
-	@echo "  sync-develop     Fetch, checkout develop, and pull origin develop"
+	@echo "  sync-develop     Fetch, switch to develop, and pull origin develop"
 	@echo "  rebase-develop   Rebase onto origin/develop"
 
 run:
@@ -100,7 +100,7 @@ fetch:
 
 sync-develop:
 	git fetch origin
-	git checkout develop
+	git switch develop
 	git pull origin develop
 
 rebase-develop:

--- a/README.md
+++ b/README.md
@@ -7,27 +7,36 @@ make help # 이용 가능한 모든 명령어 확인 가능
 
 # 명령어 이용 예시
 make run # Django 개발 서버 실행
+make dtest qna # 도커 컨테이너에서 qna 앱 테스트 실행
+make logs django # Docker django service 로그만 확인
 ```
 
 주요 타겟:
 
-- `make format` - 코드 포맷팅 실행 (black + isort + mypy)
-- `make test` - mypy 및 테스트를 커버리지와 함께 실행
-- `make run` - Django 개발 서버 실행
-- `make makemigrations` - 마이그레이션 생성
-- `make makemigrations APP=app_name` - 마이그레이션 생성 (선택적으로 앱 지정)
-- `make migrate` - 마이그레이션 적용
-- `make migrate APP=app_name` - 마이그레이션 적용 (선택적으로 앱 지정)
-- `make shell` - Django 셸 실행
-- `make dbshell` - 데이터베이스 셸 실행
-- `make build` - Docker 이미지 빌드
-- `make up` - Docker 서비스 시작
-- `make down` - Docker 서비스 종료
-- `make restart` - Docker 서비스 재시작
-- `make logs` - Docker 로그 확인
-- `make ps` - Docker 서비스 목록 확인
-- `make dtest` - Docker 컨테이너에서 테스트 실행
-- `make dmypy-reset` - dmypy 데몬 중지 및 캐시 삭제
-- `make push-force` - 안전한 강제 푸시 실행
-- `make fetch` - 원격(origin) 최신 내역 가져오기
-- `make rebase-develop` - origin/develop 기준으로 리베이스
+1. Local 환경 커맨드
+   - `make run` - Django 개발 서버 실행
+   - `make format` - 코드 포맷팅 실행 (black + isort + mypy)
+   - `make test [app_name]` - mypy 및 테스트를 커버리지와 함께 실행 [특정 앱 지정]
+   - `make makemigrations [app_name]` - 마이그레이션 생성 [특정 앱 지정]
+   - `make migrate [app_name]` - 마이그레이션 적용 [특정 앱 지정]
+   - `make shell` - Django 셸 실행
+   - `make dbshell` - 데이터베이스 셸 실행
+2. Docker 환경 커맨드
+   - `make dtest [app_name|path]` - 컨테이너에서 테스트 실행 [특정 앱 | 폴더 지정]
+   - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 생성 [특정 앱 지정]
+   - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 적용 [특정 앱 지정]
+   - `make dshell` - 컨테이너에서 Django 셸 실행
+   - `make ddbshell` - 컨테이너에서 데이터베이스 셸 실행
+3. Docker 관리
+   - `make build [service_name]` - Docker 이미지 빌드 [특정 서비스 지정]
+   - `make up [service_name]` - Docker 서비스 시작 [특정 서비스 지정]
+   - `make down` - Docker 서비스 종료
+   - `make restart` - Docker 서비스 재시작
+   - `make logs [service_name]` - Docker 로그 확인 [특정 서비스 지정]
+   - `make ps` - Docker 서비스 목록 확인
+4. 기타 유틸리티
+   - `make dmypy-reset` - dmypy 데몬 중지 및 캐시 삭제
+   - `make push-force` - 안전한 강제 푸시 실행
+   - `make fetch` - 원격(origin) 최신 내역 가져오기
+   - `make sync-develop` - 원격 최신 내역 가져오기 + develop 브랜치 이동&pull
+   - `make rebase-develop` - origin/develop 기준으로 리베이스

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make logs django # Docker django service 로그만 확인
    - `make ps` - Docker 서비스 목록 확인
 4. 기타 유틸리티
    - `make dmypy-reset` - dmypy 데몬 중지 및 캐시 삭제
-   - `make push-force` - 안전한 강제 푸시 실행
+   - `make push-force [branch_name]` - 안전한 강제 푸시 실행 [특정 브랜치 지정]
    - `make fetch` - 원격(origin) 최신 내역 가져오기
    - `make sync-develop` - 원격 최신 내역 가져오기 + develop 브랜치 이동&pull
    - `make rebase-develop` - origin/develop 기준으로 리베이스

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ make logs django # Docker django service 로그만 확인
    - `make shell` - Django 셸 실행
    - `make dbshell` - 데이터베이스 셸 실행
 2. Docker 환경 커맨드
-   - `make dtest [app_name|path]` - 컨테이너에서 테스트 실행 [특정 앱 | 폴더 지정]
+   - `make dtest [app_name|path]` - 컨테이너에서 테스트 & 커버리지 실행 [특정 앱 | 폴더 지정]
    - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 생성 [특정 앱 지정]
-   - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 적용 [특정 앱 지정]
+   - `make dmigrate [app_name]` - 컨테이너에서 마이그레이션 적용 [특정 앱 지정]
    - `make dshell` - 컨테이너에서 Django 셸 실행
    - `make ddbshell` - 컨테이너에서 데이터베이스 셸 실행
 3. Docker 관리
@@ -38,5 +38,5 @@ make logs django # Docker django service 로그만 확인
    - `make dmypy-reset` - dmypy 데몬 중지 및 캐시 삭제
    - `make push-force [branch_name]` - 안전한 강제 푸시 실행 [특정 브랜치 지정]
    - `make fetch` - 원격(origin) 최신 내역 가져오기
-   - `make sync-develop` - 원격 최신 내역 가져오기 + develop 브랜치 이동&pull
+   - `make sync-develop` - 원격 최신 내역 가져오기 + develop 브랜치로 이동 + pull develop 브랜치
    - `make rebase-develop` - origin/develop 기준으로 리베이스

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ make logs django # Docker django service 로그만 확인
 
 주요 타겟:
 
-1. Local 환경 커맨드
+- Local 환경 커맨드
    - `make run` - Django 개발 서버 실행
    - `make format` - 코드 포맷팅 실행 (black + isort + mypy)
    - `make test [app_name]` - mypy 및 테스트를 커버리지와 함께 실행 [특정 앱 지정]
@@ -21,20 +21,20 @@ make logs django # Docker django service 로그만 확인
    - `make migrate [app_name]` - 마이그레이션 적용 [특정 앱 지정]
    - `make shell` - Django 셸 실행
    - `make dbshell` - 데이터베이스 셸 실행
-2. Docker 환경 커맨드
+- Docker 환경 커맨드
    - `make dtest [app_name|path]` - 컨테이너에서 테스트 & 커버리지 실행 [특정 앱 | 폴더 지정]
    - `make dmakemigrations [app_name]` - 컨테이너에서 마이그레이션 생성 [특정 앱 지정]
    - `make dmigrate [app_name]` - 컨테이너에서 마이그레이션 적용 [특정 앱 지정]
    - `make dshell` - 컨테이너에서 Django 셸 실행
    - `make ddbshell` - 컨테이너에서 데이터베이스 셸 실행
-3. Docker 관리
+- Docker 관리
    - `make build [service_name]` - Docker 이미지 빌드 [특정 서비스 지정]
    - `make up [service_name]` - Docker 서비스 시작 [특정 서비스 지정]
    - `make down` - Docker 서비스 종료
    - `make restart` - Docker 서비스 재시작
    - `make logs [service_name]` - Docker 로그 확인 [특정 서비스 지정]
    - `make ps` - Docker 서비스 목록 확인
-4. 기타 유틸리티
+- 기타 유틸리티
    - `make dmypy-reset` - dmypy 데몬 중지 및 캐시 삭제
    - `make push-force [branch_name]` - 안전한 강제 푸시 실행 [특정 브랜치 지정]
    - `make fetch` - 원격(origin) 최신 내역 가져오기

--- a/resources/scripts/test.sh
+++ b/resources/scripts/test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -eo pipefail
 
 COLOR_GREEN=`tput setaf 2;`
@@ -11,9 +12,15 @@ echo "${COLOR_BLUE}Starting mypy${COLOR_NC}"
 poetry run dmypy run -- .
 echo "OK"
 
+TEST_TARGET=${1:-apps}
+[[ "$TEST_TARGET" != apps* ]] && TEST_TARGET="apps/$TEST_TARGET"
+COVERAGE_SOURCE=$(echo "$TEST_TARGET" | cut -d'/' -f1,2)
+
 echo "${COLOR_BLUE}Starting Django Test with coverage${COLOR_NC}"
-poetry run coverage run manage.py test
+echo "- Coverage Source: $COVERAGE_SOURCE"
+echo "- Test Target: $TEST_TARGET"
+poetry run coverage run --source="$COVERAGE_SOURCE" manage.py test "$TEST_TARGET"
 poetry run coverage report -m
 poetry run coverage html
 
-echo "${COLOR_GREEN}Successfully Run Mypy and Test!!"
+echo "${COLOR_GREEN}Successfully Run Mypy and Test for $TEST_TARGET!!"

--- a/resources/scripts/test.sh
+++ b/resources/scripts/test.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -eo pipefail
 
 COLOR_GREEN=`tput setaf 2;`
@@ -12,15 +11,9 @@ echo "${COLOR_BLUE}Starting mypy${COLOR_NC}"
 poetry run dmypy run -- .
 echo "OK"
 
-TEST_TARGET=${1:-apps}
-[[ "$TEST_TARGET" != apps* ]] && TEST_TARGET="apps/$TEST_TARGET"
-COVERAGE_SOURCE=$(echo "$TEST_TARGET" | cut -d'/' -f1,2)
-
 echo "${COLOR_BLUE}Starting Django Test with coverage${COLOR_NC}"
-echo "- Coverage Source: $COVERAGE_SOURCE"
-echo "- Test Target: $TEST_TARGET"
-poetry run coverage run --source="$COVERAGE_SOURCE" manage.py test "$TEST_TARGET"
+poetry run coverage run manage.py test
 poetry run coverage report -m
 poetry run coverage html
 
-echo "${COLOR_GREEN}Successfully Run Mypy and Test for $TEST_TARGET!!"
+echo "${COLOR_GREEN}Successfully Run Mypy and Test!!"


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 
    - Makefile에 인자 처리 기능 추가
    - 입력인자에 따라 test.sh에 특정 앱만 테스트 동작하도록 수정

## 📄 상세 내용
- [x] Makefile - make 커맨드 다음에 입력인자를 받을 수 있게 ARGS변수 추가 (예: make build django)
- [x] dtest, dmakemigrations, dmigrate등에 특정 앱 지정할 수 있는 옵션 추가
    - 예: make dtest qna 
- [x] make dtest에 옵션인자가 있을때 test.sh에서 해당 앱만 처리하도록 로직 추가
- [x] 기존 makemigrations, migrate도 (APP)에서 (ARGS)로 인자 입력방식 변경
    - make makemigrations APP=app_name ->  make makemigrations app_name
    - make migrate APP=app_name ->  make migrate app_name
- [x] sync-develop 추가
- [x] push-force에 ARGS가 있을때 ARGS 브랜치에서 push-force 동작하도록 추가
- [x] 변경내용에 대해 READMD.md 반영

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
