### PR TITLE
[feature/qna/get_questions] feat: 질문 목록 조회 API 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,28 @@ fetch:
 	git fetch origin
 
 sync-develop:
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "⚠️  경고: 커밋되지 않은 변경 사항이 있습니다."; \
+		echo "⚠️  브랜치를 이동하면 작업 내용이 꼬일 수 있습니다."; \
+		read -p "⚠️  계속 진행하시겠습니까? [y/N]: " CONFIRM < /dev/tty; \
+		if [ "$$CONFIRM" != "y" ] && [ "$$CONFIRM" != "Y" ]; then \
+			echo "❌ 작업을 중단합니다. 기존 작업한 내역을 commit 또는 stash한 후에 다시 시도하세요."; \
+			exit 1; \
+		fi; \
+	fi
+	@echo ""
+	@echo "---sync-develop 실행"
 	git fetch origin
+	@echo ""
+	@echo "---develop 브랜치로 이동합니다."
 	git switch develop
+	@echo ""
+	@echo "---🔄 develop 브랜치 최신화 중..."
 	git pull origin develop
+	@echo ""
+	@echo "---develop 브랜치가 최신화 되었습니다."
+	@echo "---현재 브랜치는 develop 입니다"
+	@echo "🚨 🚨 🚨 🚨 🚨 작업할 브랜치로 이동하세요🚨 🚨 🚨 🚨 🚨"
 
 rebase-develop:
 	git fetch origin

--- a/apps/core/utils/pagination.py
+++ b/apps/core/utils/pagination.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+
 from rest_framework.pagination import CursorPagination, PageNumberPagination
 from rest_framework.response import Response
 
@@ -39,4 +40,3 @@ class QnAPagination(PageNumberPagination):
                 "results": data,
             }
         )
-

--- a/apps/core/utils/pagination.py
+++ b/apps/core/utils/pagination.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import Any
 from rest_framework.pagination import CursorPagination, PageNumberPagination
-
+from rest_framework.response import Response
 
 class ChatbotSessionCursorPagination(CursorPagination):
     page_size = 10
@@ -14,3 +15,28 @@ class SimplePagePagination(PageNumberPagination):
     page_query_param = "page"
     page_size_query_param = "size"
     max_page_size = 100
+
+
+
+class QnAPagination(PageNumberPagination):
+    """
+    질의응답 목록 조회를 위한 페이지네이션
+    """
+
+    page_size_query_param = "size"
+    max_page_size = 100
+
+    def get_paginated_response(self, data: Any) -> Response:
+        """페이지네이션 응답 생성"""
+        if self.page is None:
+            return Response(data)
+
+        return Response(
+            {
+                "count": self.page.paginator.count,
+                "next": self.get_next_link(),
+                "previous": self.get_previous_link(),
+                "results": data,
+            }
+        )
+

--- a/apps/core/utils/pagination.py
+++ b/apps/core/utils/pagination.py
@@ -4,6 +4,7 @@ from typing import Any
 from rest_framework.pagination import CursorPagination, PageNumberPagination
 from rest_framework.response import Response
 
+
 class ChatbotSessionCursorPagination(CursorPagination):
     page_size = 10
     ordering = "-created_at"
@@ -15,7 +16,6 @@ class SimplePagePagination(PageNumberPagination):
     page_query_param = "page"
     page_size_query_param = "size"
     max_page_size = 100
-
 
 
 class QnAPagination(PageNumberPagination):

--- a/apps/qna/exceptions/question_exception.py
+++ b/apps/qna/exceptions/question_exception.py
@@ -22,13 +22,3 @@ class QuestionPermissionDeniedException(QuestionBaseException):
     status_code: int = status.HTTP_403_FORBIDDEN
     default_detail = "해당 질문에 대한 권한이 없습니다."
     default_code = "permission_denied"
-
-
-class QuestionAuthenticationRequiredException(QuestionBaseException):
-    """
-    인증 필요 예외 (401 Unauthorized)
-    """
-
-    status_code: int = status.HTTP_401_UNAUTHORIZED
-    default_detail = "인증 정보가 유효하지 않습니다."
-    default_code = "authentication_failed"

--- a/apps/qna/serializers/question_base.py
+++ b/apps/qna/serializers/question_base.py
@@ -7,10 +7,11 @@ from apps.qna.exceptions.question_exception import QuestionBaseException
 
 class QnAVersionedValidationMixin:
     """
-    QnA 시리얼라이저에서 공통적으로 사용할 예외 처리 로직을 담은 Mixin class
+    QnA 시리얼라이저용 공통 예외 처리 Mixin
     """
 
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:  # DRF의 내장 validate 로직에서 발생하는 에러 캐치
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        """DRF 내장 검증 로직 에러 캐치 및 커스텀 예외 반환"""
         try:
             validated_data = super().validate(attrs)  # type: ignore
             return cast(dict[str, Any], validated_data)

--- a/apps/qna/serializers/question_serializer.py
+++ b/apps/qna/serializers/question_serializer.py
@@ -16,7 +16,7 @@ class QuestionQuerySerializer(QnAVersionedValidationMixin, serializers.Serialize
     search_keyword = serializers.CharField(required=False, allow_blank=True)
     category_id = serializers.IntegerField(required=False)
     answer_status = serializers.ChoiceField(choices=["waiting", "answered"], required=False)
-    sort = serializers.CharField(default="latest")
+    sort = serializers.ChoiceField(choices=["latest", "oldest", "most_views"], default="latest")
     page = serializers.IntegerField(default=1)
     size = serializers.IntegerField(default=10)
 
@@ -90,8 +90,8 @@ class QuestionListSerializer(serializers.ModelSerializer[Question]):
         ]
 
     def get_content_preview(self, obj: Question) -> str:
-        """본문 텍스트 앞 100자 프리뷰 생성"""
-        return obj.content[:100] + "..." if len(obj.content) > 100 else obj.content
+        """본문 프리뷰 생성"""
+        return obj.content[:50] + "..." if len(obj.content) > 100 else obj.content
 
     def get_thumbnail_img_url(self, obj: Question) -> Any:
         """본문 내용에서 첫 번째 이미지 URL을 파싱하여 반환"""

--- a/apps/qna/serializers/question_serializer.py
+++ b/apps/qna/serializers/question_serializer.py
@@ -1,12 +1,108 @@
-from typing import Any, cast
+from typing import Any
 
 from rest_framework import serializers
 
-from apps.qna.models import Question
+from apps.qna.models import Question, QuestionCategory
 from apps.qna.serializers.question_base import QnAVersionedValidationMixin
+from apps.qna.utils.content_parser import ContentParser
+from apps.users.models import User
+
+
+class QuestionQuerySerializer(QnAVersionedValidationMixin, serializers.Serializer[Any]):
+    """
+    질문 목록 조회를 위한 쿼리 파라미터 시리얼라이저
+    """
+
+    search_keyword = serializers.CharField(required=False, allow_blank=True)
+    category_id = serializers.IntegerField(required=False)
+    answer_status = serializers.ChoiceField(choices=["waiting", "answered"], required=False)
+    sort = serializers.CharField(default="latest")
+    page = serializers.IntegerField(default=1)
+    size = serializers.IntegerField(default=10)
+
+
+class QuestionCategoryListSerializer(serializers.ModelSerializer[QuestionCategory]):
+    """
+    질의응답 목록용 카테고리 시리얼라이저 (대 > 중 > 소 형태)
+    """
+
+    depth = serializers.SerializerMethodField()
+    names = serializers.SerializerMethodField()
+
+    class Meta:
+        model = QuestionCategory
+        fields = ["id", "depth", "names"]
+
+    def get_depth(self, obj: QuestionCategory) -> int:
+        """모델에 필드가 없으므로 부모를 거슬러 올라가며 깊이를 계산"""
+        depth = 0
+        curr = obj.parent
+        while curr:
+            depth += 1
+            curr = curr.parent
+        return depth
+
+    def get_names(self, obj: QuestionCategory) -> list[str]:
+        """부모 카테고리를 거슬러 올라가며 전체 경로 이름을 리스트로 생성"""
+        names: list[str] = []
+        curr: QuestionCategory | None = obj
+        while curr:
+            names.insert(0, curr.name)
+            curr = curr.parent
+        return names
+
+
+class QuestionAuthorSerializer(serializers.ModelSerializer[User]):
+    """
+    질문 작성자 정보 시리얼라이저
+    """
+
+    profile_image_url = serializers.ImageField(source="profile_img_url", use_url=True)
+
+    class Meta:
+        model = User
+        fields = ["id", "nickname", "profile_image_url"]
+
+
+class QuestionListSerializer(serializers.ModelSerializer[Question]):
+    """
+    질의응답 목록 조회 카드 형태 항목 시리얼라이저
+    """
+
+    category = QuestionCategoryListSerializer(read_only=True)
+    author = QuestionAuthorSerializer(read_only=True)
+    content_preview = serializers.SerializerMethodField()
+    answer_count = serializers.IntegerField(read_only=True)
+    thumbnail_img_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Question
+        fields = [
+            "id",
+            "category",
+            "author",
+            "title",
+            "content_preview",
+            "answer_count",
+            "view_count",
+            "created_at",
+            "thumbnail_img_url",
+        ]
+
+    def get_content_preview(self, obj: Question) -> str:
+        """본문 텍스트 앞 100자 프리뷰 생성"""
+        return obj.content[:100] + "..." if len(obj.content) > 100 else obj.content
+
+    def get_thumbnail_img_url(self, obj: Question) -> Any:
+        """본문 내용에서 첫 번째 이미지 URL을 파싱하여 반환"""
+        return ContentParser.extract_thumbnail_img_url(obj.content)
 
 
 class QuestionCreateSerializer(QnAVersionedValidationMixin, serializers.ModelSerializer[Question]):
+    """
+    질문 등록 시리얼라이저
+    """
+
     category_id = serializers.IntegerField(required=True, help_text="카테고리 ID (소분류)")
 
     class Meta:
@@ -15,5 +111,9 @@ class QuestionCreateSerializer(QnAVersionedValidationMixin, serializers.ModelSer
 
 
 class QuestionCreateResponseSerializer(QnAVersionedValidationMixin, serializers.Serializer[Any]):
+    """
+    질문 등록 응답 시리얼라이저
+    """
+
     message = serializers.CharField(default="질문이 성공적으로 등록되었습니다.")
     question_id = serializers.IntegerField(source="id")

--- a/apps/qna/tests/test_question_create.py
+++ b/apps/qna/tests/test_question_create.py
@@ -33,6 +33,7 @@ class QuestionCreateAPITest(TestCase):
             name="test1",
             nickname="수강생",
             role="STUDENT",
+            gender="MAIL",
             birthday="1990-01-01",
             is_active=True,
         )
@@ -44,6 +45,7 @@ class QuestionCreateAPITest(TestCase):
             name="test2",
             nickname="일반유저",
             role="USER",
+            gender="FEMAIL",
             birthday="1995-05-05",
             is_active=True,
         )

--- a/apps/qna/tests/test_question_list.py
+++ b/apps/qna/tests/test_question_list.py
@@ -1,0 +1,128 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from rest_framework import status
+
+from apps.qna.models import Answer, Question, QuestionCategory
+
+User = get_user_model()
+
+
+class QuestionListAPITest(TestCase):
+    """
+    질문 목록 조회 API (GET) 테스트
+    - 검색, 필터링, 정렬 및 페이지네이션 검증
+    """
+
+    def setUp(self) -> None:
+        # Django 내장 TestClient 초기화
+        self.client = Client()
+
+        # 테스트용 카테고리 생성 (계층형)
+        self.category_fe = QuestionCategory.objects.create(name="프론트엔드")
+        self.category_react = QuestionCategory.objects.create(name="React", parent=self.category_fe)
+        self.category_be = QuestionCategory.objects.create(name="백엔드")
+
+        # 테스트용 유저 생성
+        self.user = User.objects.create_user(
+            email="tester@ozcoding.com",
+            password="password123",
+            name="김테스터",
+            nickname="테스터",
+            role="STUDENT",
+            birthday="1990-01-01",
+        )
+
+        # 테스트용 질문 데이터 대량 생성 (페이지네이션 및 필터링용)
+        # Q1: React 카테고리, 이미지 포함, 답변 없음 (waiting)
+        self.q1 = Question.objects.create(
+            author=self.user,
+            category=self.category_react,
+            title="React Hooks 질문",
+            content="![thumb](https://example.com/image.png) useEffect 사용법이 궁금해요.",
+        )
+
+        # Q2: 백엔드 카테고리, 답변 있음 (answered)
+        self.q2 = Question.objects.create(
+            author=self.user,
+            category=self.category_be,
+            title="Django ORM 성능 최적화",
+            content="select_related와 prefetch_related의 차이는 무엇인가요?",
+        )
+        # Q2에 대한 답변 생성
+        Answer.objects.create(author=self.user, question=self.q2, content="답변입니다.")
+
+        # URL 설정
+        self.url = reverse("question-list-create")
+
+    def test_get_question_list_success(self) -> None:
+        """[성공] 필터 없이 전체 목록 조회 시 최신순으로 반환되어야 함"""
+        response = self.client.get(self.url)
+        data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # QnAPagination 구조 확인 (results 키 포함 여부)
+        self.assertIn("results", data)
+        # 최신순 정렬 확인 (최근 생성된 q2가 첫 번째)
+        self.assertEqual(data["results"][0]["id"], self.q2.id)
+        # 썸네일 파싱 확인 (q1의 content에서 추출)
+        self.assertEqual(data["results"][1]["thumbnail_img_url"], "https://example.com/image.png")
+
+    def test_filter_by_category(self) -> None:
+        """[성공] 특정 카테고리 ID로 필터링 시 해당 질문만 반환되어야 함"""
+        response = self.client.get(self.url, {"category_id": self.category_be.id})
+        data = response.json()
+
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["title"], "Django ORM 성능 최적화")
+
+    def test_search_by_keyword(self) -> None:
+        """[성공] 검색어 입력 시 제목 또는 내용에서 검색되어야 함"""
+        response = self.client.get(self.url, {"search_keyword": "Hooks"})
+        data = response.json()
+
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["title"], "React Hooks 질문")
+
+    def test_filter_by_answer_status_waiting(self) -> None:
+        """[성공] answer_status가 'waiting'인 경우 답변이 없는 질문만 반환"""
+        response = self.client.get(self.url, {"answer_status": "waiting"})
+        data = response.json()
+
+        # 답변이 없는 q1만 나와야 함
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["id"], self.q1.id)
+
+    def test_filter_by_answer_status_answered(self) -> None:
+        """[성공] answer_status가 'answered'인 경우 답변이 1개 이상인 질문만 반환"""
+        response = self.client.get(self.url, {"answer_status": "answered"})
+        data = response.json()
+
+        # 답변이 있는 q2만 나와야 함
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["id"], self.q2.id)
+
+    def test_pagination_size(self) -> None:
+        """[성공] size 파라미터에 따라 반환되는 데이터 개수가 조절되어야 함"""
+        # 테스트를 위해 추가 데이터 생성
+        for i in range(5):
+            Question.objects.create(author=self.user, category=self.category_be, title=f"추가 질문 {i}", content="내용")
+
+        response = self.client.get(self.url, {"size": 3})
+        data = response.json()
+
+        self.assertEqual(len(data["results"]), 3)
+        self.assertIsNotNone(data["next"])  # 다음 페이지 링크 확인
+
+    def test_question_list_performance(self) -> None:
+        """[성공] 질문 목록 조회 시 발생하는 쿼리 수 검증"""
+
+        # 쿼리 발생 내역 캡처
+        with CaptureQueriesContext(connection) as context:
+            self.client.get(self.url)
+
+        self.assertEqual(len(context), 2, f"Expected 2 or fewer queries, but got {len(context)}")

--- a/apps/qna/tests/test_question_list.py
+++ b/apps/qna/tests/test_question_list.py
@@ -34,6 +34,7 @@ class QuestionListAPITest(TestCase):
             name="김테스터",
             nickname="테스터",
             role="STUDENT",
+            gender="MALE",
             birthday="1990-01-01",
         )
 

--- a/apps/qna/urls/question_urls.py
+++ b/apps/qna/urls/question_urls.py
@@ -1,8 +1,7 @@
 from django.urls import path
 
-from apps.qna.views.question_view import QuestionCreateAPIView
+from apps.qna.views.question_view import QuestionCreateListAPIView
 
 urlpatterns = [
-    # 엔드포인트는 동일하게 유지하되 APIView 클래스 연결
-    path("questions", QuestionCreateAPIView.as_view(), name="question-create"),
+    path("questions", QuestionCreateListAPIView.as_view(), name="question-list-create"),
 ]

--- a/apps/qna/utils/content_parser.py
+++ b/apps/qna/utils/content_parser.py
@@ -1,0 +1,25 @@
+import re
+from typing import Optional
+
+
+class ContentParser:
+    """
+    질문 본문(Markdown 등)에서 정보를 추출하는 유틸리티 클래스
+    """
+
+    @staticmethod
+    def extract_thumbnail_img_url(content: str) -> Optional[str]:
+        """본문 텍스트 내 이미지 태그를 찾아 첫 번째 이미지의 URL을 반환"""
+        # 마크다운 이미지 패턴: ![...](url)
+        markdown_image_pattern = r"!\[.*?\]\((.*?)\)"
+        match = re.search(markdown_image_pattern, content)
+        if match:
+            return match.group(1)
+
+        # HTML 이미지 태그 패턴: <img src="url">
+        html_image_pattern = r'<img [^>]*src="([^"]+)"'
+        match = re.search(html_image_pattern, content)
+        if match:
+            return match.group(1)
+
+        return None

--- a/apps/qna/utils/permissions.py
+++ b/apps/qna/utils/permissions.py
@@ -4,7 +4,6 @@ from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 
 from apps.qna.exceptions.question_exception import (
-    QuestionAuthenticationRequiredException,
     QuestionPermissionDeniedException,
 )
 
@@ -15,9 +14,7 @@ class IsStudent(BasePermission):
     """
 
     def has_permission(self, request: Request, view: Any) -> bool:
-        if not (request.user and request.user.is_authenticated):  # 로그인 여부 확인
-            raise QuestionAuthenticationRequiredException()
-
+        """role이 STUDENT인지 검증"""
         user_role = getattr(request.user, "role", None)
         if not user_role or str(user_role) != "STUDENT":
             raise QuestionPermissionDeniedException()

--- a/apps/qna/utils/question_list_pagination.py
+++ b/apps/qna/utils/question_list_pagination.py
@@ -1,0 +1,28 @@
+from typing import Any, Type
+
+from rest_framework.response import Response
+from rest_framework.serializers import Serializer
+
+from apps.core.utils.pagination import QnAPagination
+
+
+class QnAPaginator:
+    """
+    QnA 전용 페이지네이션 응답 빌더
+    """
+
+    @classmethod
+    def get_paginated_data_response(
+        cls, queryset: Any, request: Any, serializer_class: Type[Serializer[Any]], view: Any = None
+    ) -> Response:
+        """QuerySet 기반 페이지네이션 응답 객체 생성"""
+        # core에 정의된 페이지네이션 인스턴스 생성
+        instance = QnAPagination()
+        page = instance.paginate_queryset(queryset, request, view=view)
+
+        if page is not None:
+            serializer = serializer_class(page, many=True)
+            return instance.get_paginated_response(serializer.data)
+
+        serializer = serializer_class(queryset, many=True)
+        return Response(serializer.data)

--- a/apps/qna/views/question_view.py
+++ b/apps/qna/views/question_view.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,7 +26,7 @@ class QuestionCreateListAPIView(APIView):
 
     def get_permissions(self) -> list[Any]:
         if self.request.method == "POST":
-            return [IsStudent()]
+            return [IsAuthenticated(), IsStudent()]
         return [AllowAny()]
 
     @extend_schema(

--- a/apps/qna/views/question_view.py
+++ b/apps/qna/views/question_view.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -7,35 +10,84 @@ from rest_framework.views import APIView
 from apps.qna.serializers.question_serializer import (
     QuestionCreateResponseSerializer,
     QuestionCreateSerializer,
+    QuestionListSerializer,
+    QuestionQuerySerializer,
 )
 from apps.qna.services.question_service import QuestionService
 from apps.qna.utils.permissions import IsStudent
+from apps.qna.utils.question_list_pagination import QnAPaginator
 
 
-# 질문 등록
-class QuestionCreateAPIView(APIView):
-    permission_classes = [IsStudent]  # 학생만 question 등록 가능
+# 질문 등록 & 조회
+class QuestionCreateListAPIView(APIView):
+    """
+    질의응답 질문 등록 및 목록 조회 API
+    """
+
+    def get_permissions(self) -> list[Any]:
+        if self.request.method == "POST":
+            return [IsStudent()]
+        return [AllowAny()]
+
+    @extend_schema(
+        summary="질문 목록 조회 API",
+        description="""
+        등록된 모든 질문 목록을 최신순으로 조회합니다.
+        질의응답 목록에서 조회가능한 항목
+        - 질의응답 카테고리 (대분류 > 중분류 > 소분류 형태)
+        - 작성자 정보
+            프로필 이미지
+            닉네임
+        - 질의응답 제목
+        - 질문 내용
+        - 답변 수
+        - 조회수
+        - 질문 작성일시
+        - 질문 내용에 포함된 이미지의 썸네일 이미지
+        """,
+        parameters=[QuestionQuerySerializer],
+        responses={
+            200: QuestionListSerializer(many=True),
+            400: OpenApiResponse(description="Bad Request"),
+            404: OpenApiResponse(description="Not Found"),
+        },
+        tags=["QnA"],
+    )
+    def get(self, request: Request) -> Response:
+        """필터링 및 검색된 질문 목록 반환"""
+        # 쿼리 파라미터 검증
+        query_serializer = QuestionQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+
+        # 데이터 조회
+        queryset = QuestionService.get_question_list(query_serializer.validated_data)
+
+        # Response 생성
+        return QnAPaginator.get_paginated_data_response(
+            queryset=queryset, request=request, serializer_class=QuestionListSerializer, view=self
+        )
 
     @extend_schema(
         summary="질문 등록 API",
-        description=(
-            "수강생 권한을 가진 로그인 유저가 질문을 등록합니다.\n\n"
-            "질문 등록 시 입력 항목\n"
-            "- 제목: 질문의 핵심 요약\n"
-            "- 질문내용: 마크다운 문법 사용 가능, 이미지 첨부 가능\n"
-            "- 카테고리: 대분류 > 중분류 > 소분류\n"
-            "- 내용에 포함된 이미지들의 PK 리스트"
-        ),
+        description="""
+        수강생 권한을 가진 로그인 유저가 질문을 등록합니다.
+        질문 등록 시 입력 항목
+        - 제목: 질문의 핵심 요약
+        - 질문내용: 마크다운 문법 사용 가능, 이미지 첨부 가능
+        - 카테고리: 대분류 > 중분류 > 소분류
+        - 내용에 포함된 이미지들의 PK 리스트
+        """,
         request=QuestionCreateSerializer,
         responses={
             201: OpenApiResponse(response=QuestionCreateResponseSerializer, description="질문 등록 성공"),
-            400: OpenApiResponse(description="잘못된 요청 데이터 (Bad Request)"),
-            401: OpenApiResponse(description="인증 실패 (Unauthorized)"),
-            403: OpenApiResponse(description="접근 권한 없음 (Forbidden)"),
+            400: OpenApiResponse(description="Bad Request"),
+            401: OpenApiResponse(description="Unauthorized"),
+            403: OpenApiResponse(description="Forbidden"),
         },
         tags=["QnA"],
     )
     def post(self, request: Request) -> Response:
+        """질문 생성"""
         serializer = QuestionCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: feat: 질문 목록 조회 API 구현 및 테스트 코드 생성

## 📄 상세 내용
- [x] 질문 목록을 조회 할 수 있는 기능 추가
- [x] 페이지네이션 공통/question 분리 구현
- [x] 쿼리 파라미터, 목록 조회 카드 항목, 카테고리, 작성자 정보 시리얼라이저 구현
- [x] 검색, 필터링, 정렬 로직 구현
- [x] Thumbnail image url 추출 로직 구현
- [x] 테스트 코드 작성
- [x] 주석 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
