### PR TITLE
[feature/withdrawal] feat: 회원 탈퇴 요청 API 추가

### DIFF
--- a/apps/users/serializers/__init__.py
+++ b/apps/users/serializers/__init__.py
@@ -4,10 +4,11 @@ from .email_verification_serializer import (
 )
 from .sign_up_serializer import SignupNicknameCheckSerializer, SignUpSerializer
 from .withdrawal_serializer import WithdrawalRequestSerializer
+
 __all__ = [
     "SignUpSerializer",
     "SignupNicknameCheckSerializer",
     "SendEmailVerificationSerializer",
     "VerifyEmailSerializer",
-    "WithdrawalRequestSerializer"
+    "WithdrawalRequestSerializer",
 ]

--- a/apps/users/serializers/__init__.py
+++ b/apps/users/serializers/__init__.py
@@ -3,10 +3,11 @@ from .email_verification_serializer import (
     VerifyEmailSerializer,
 )
 from .sign_up_serializer import SignupNicknameCheckSerializer, SignUpSerializer
-
+from .withdrawal_serializer import WithdrawalRequestSerializer
 __all__ = [
     "SignUpSerializer",
     "SignupNicknameCheckSerializer",
     "SendEmailVerificationSerializer",
     "VerifyEmailSerializer",
+    "WithdrawalRequestSerializer"
 ]

--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -6,3 +6,9 @@ from apps.users.models.withdrawal import Withdrawal
 class WithdrawalRequestSerializer(serializers.Serializer):  # type: ignore[type-arg]
     reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)
     reason_detail = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
+class WithdrawalResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    message = serializers.CharField()
+    due_date = serializers.DateTimeField()
+    reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)

--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -10,5 +10,5 @@ class WithdrawalRequestSerializer(serializers.Serializer):  # type: ignore[type-
 
 class WithdrawalResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     message = serializers.CharField()
-    due_date = serializers.DateTimeField()
+    due_date = serializers.DateField()
     reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)

--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+from apps.users.models.withdrawal import Withdrawal
+
+
+class WithdrawalRequestSerializer(serializers.Serializer):
+    reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices) # type: ignore[arg-type]
+    reason_detail = serializers.CharField(allow_blank=False, trim_whitespace=True)

--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -3,6 +3,6 @@ from rest_framework import serializers
 from apps.users.models.withdrawal import Withdrawal
 
 
-class WithdrawalRequestSerializer(serializers.Serializer):
-    reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices) # type: ignore[arg-type]
+class WithdrawalRequestSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)
     reason_detail = serializers.CharField(allow_blank=False, trim_whitespace=True)

--- a/apps/users/tests/test_withdrawal.py
+++ b/apps/users/tests/test_withdrawal.py
@@ -1,0 +1,53 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework import status
+from apps.users.models.withdrawal import Withdrawal
+from datetime import date
+
+class WithdrawalAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.withdrawal_url = "/api/v1/accounts/withdrawal/"
+
+        User = get_user_model()
+        self.email = "withdrawal_test@example.com"
+        self.password = "Testpass123!"
+        self.user = User.objects.create_user(
+            email=self.email,
+            password=self.password,
+            birthday=date(2000, 1, 1),
+            phone_number="01012345678",
+            name="테스터",
+            nickname="tester",
+            gender="male",
+        )
+
+        access = str(RefreshToken.for_user(self.user).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+
+    def test_withdrawal_success_201_and_user_inactive(self):
+        res = self.client.post(
+            self.withdrawal_url,
+            {"reason": "PRIVACY_CONCERN", "reason_detail": "테스트 탈퇴"},
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        data = res.json()
+        self.assertIn("due_date", data)
+        self.assertEqual(data["reason"], "PRIVACY_CONCERN")
+        self.assertIn("message", data)
+
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+        self.assertTrue(Withdrawal.objects.filter(user=self.user).exists())
+
+    def test_withdrawal_invalid_reason_400(self):
+        res = self.client.post(
+            self.withdrawal_url,
+            {"reason": "INVALID", "reason_detail": "테스트"},
+            format="json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/users/tests/test_withdrawal.py
+++ b/apps/users/tests/test_withdrawal.py
@@ -1,13 +1,16 @@
-from django.contrib.auth import get_user_model
-from django.test import TestCase
-from rest_framework.test import APIClient
-from rest_framework_simplejwt.tokens import RefreshToken
-from rest_framework import status
-from apps.users.models.withdrawal import Withdrawal
 from datetime import date
 
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.users.models.withdrawal import Withdrawal
+
+
 class WithdrawalAPITests(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.client = APIClient()
         self.withdrawal_url = "/api/v1/accounts/withdrawal/"
 
@@ -27,7 +30,7 @@ class WithdrawalAPITests(TestCase):
         access = str(RefreshToken.for_user(self.user).access_token)
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
 
-    def test_withdrawal_success_201_and_user_inactive(self):
+    def test_withdrawal_success_201_and_user_inactive(self) -> None:
         res = self.client.post(
             self.withdrawal_url,
             {"reason": "PRIVACY_CONCERN", "reason_detail": "테스트 탈퇴"},
@@ -44,7 +47,7 @@ class WithdrawalAPITests(TestCase):
         self.assertFalse(self.user.is_active)
         self.assertTrue(Withdrawal.objects.filter(user=self.user).exists())
 
-    def test_withdrawal_invalid_reason_400(self):
+    def test_withdrawal_invalid_reason_400(self) -> None:
         res = self.client.post(
             self.withdrawal_url,
             {"reason": "INVALID", "reason_detail": "테스트"},

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -16,6 +16,7 @@ from apps.users.views.sms_verification_view import (
     VerifySmsAPIView,
 )
 from apps.users.views.token_refresh_view import TokenRefreshAPIView
+from apps.users.views.withdrawal_view import WithdrawalAPIView
 
 urlpatterns = [
     # 회원가입
@@ -41,4 +42,5 @@ urlpatterns = [
     path("find-email/", FindEmailAPIView.as_view(), name="find-email"),
     # 휴대폰 번호 변경
     path("change-phone/", ChangePhoneView.as_view(), name="change-phone"),
+    path("withdrawal/", WithdrawalAPIView.as_view(), name="withdrawal"),
 ]

--- a/apps/users/views/withdrawal_view.py
+++ b/apps/users/views/withdrawal_view.py
@@ -7,7 +7,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.models import Withdrawal
-from apps.users.serializers import WithdrawalRequestSerializer
+from apps.users.serializers.withdrawal_serializer import (
+    WithdrawalRequestSerializer,
+    WithdrawalResponseSerializer,
+)
 
 
 class WithdrawalAPIView(APIView):
@@ -17,14 +20,14 @@ class WithdrawalAPIView(APIView):
         tags=["accounts"],
         summary="회원 탈퇴 요청",
         request=WithdrawalRequestSerializer,
-        responses={201: "None"},
+        responses={201: WithdrawalResponseSerializer},
     )
     def post(self, request: Request) -> Response:
         user = request.user
 
         if not user.is_active:
             return Response(
-                {"error_detail": {"detail": "이미 탈퇴 처리된 계정입니다."}},
+                {"error_detail": "이미 탈퇴 처리된 계정입니다."},
                 status=status.HTTP_409_CONFLICT,
             )
 

--- a/apps/users/views/withdrawal_view.py
+++ b/apps/users/views/withdrawal_view.py
@@ -1,12 +1,14 @@
 from django.db import transaction
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
-from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from apps.users.models import Withdrawal
 from apps.users.serializers import WithdrawalRequestSerializer
-from drf_spectacular.utils import extend_schema
+
 
 class WithdrawalAPIView(APIView):
     permission_classes = [IsAuthenticated]
@@ -29,14 +31,14 @@ class WithdrawalAPIView(APIView):
         existing = Withdrawal.objects.filter(user=user).first()
         if existing:
             return Response(
-            {
-                "error_detail": {
-                    "detail": "이미 탈퇴 신청한 계정입니다.",
-                    "expire_at": existing.due_date,
-                }
-            },
-            status=status.HTTP_409_CONFLICT,
-        )
+                {
+                    "error_detail": {
+                        "detail": "이미 탈퇴 신청한 계정입니다.",
+                        "expire_at": existing.due_date,
+                    }
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
 
         serializer = WithdrawalRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/apps/users/views/withdrawal_view.py
+++ b/apps/users/views/withdrawal_view.py
@@ -1,0 +1,56 @@
+from django.db import transaction
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.request import Request
+from apps.users.models import Withdrawal
+from apps.users.serializers import WithdrawalRequestSerializer
+from drf_spectacular.utils import extend_schema
+
+class WithdrawalAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["accounts"],
+        summary="회원 탈퇴 요청",
+        request=WithdrawalRequestSerializer,
+        responses={201: "None"},
+    )
+    def post(self, request: Request) -> Response:
+        user = request.user
+
+        if not user.is_active:
+            return Response(
+                {"error_detail": {"detail": "이미 탈퇴 처리된 계정입니다."}},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        existing = Withdrawal.objects.filter(user=user).first()
+        if existing:
+            return Response(
+            {
+                "error_detail": {
+                    "detail": "이미 탈퇴 신청한 계정입니다.",
+                    "expire_at": existing.due_date,
+                }
+            },
+            status=status.HTTP_409_CONFLICT,
+        )
+
+        serializer = WithdrawalRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        with transaction.atomic():
+            withdrawal = Withdrawal.objects.create(user=user, **serializer.validated_data)
+            user.is_active = False
+            user.save(update_fields=["is_active"])
+
+        return Response(
+            {
+                "message": "회원 탈퇴 요청이 완료 되었습니다.",
+                "due_date": withdrawal.due_date,
+                "reason": withdrawal.reason,
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/apps/users/views/withdrawal_view.py
+++ b/apps/users/views/withdrawal_view.py
@@ -35,10 +35,8 @@ class WithdrawalAPIView(APIView):
         if existing:
             return Response(
                 {
-                    "error_detail": {
-                        "detail": "이미 탈퇴 신청한 계정입니다.",
-                        "expire_at": existing.due_date,
-                    }
+                    "error_detail": "이미 탈퇴 신청한 계정입니다.",
+                    "expire_at": existing.due_date,
                 },
                 status=status.HTTP_409_CONFLICT,
             )
@@ -51,11 +49,11 @@ class WithdrawalAPIView(APIView):
             user.is_active = False
             user.save(update_fields=["is_active"])
 
-        return Response(
+        response_serializer = WithdrawalResponseSerializer(
             {
                 "message": "회원 탈퇴 요청이 완료 되었습니다.",
                 "due_date": withdrawal.due_date,
                 "reason": withdrawal.reason,
-            },
-            status=status.HTTP_201_CREATED,
+            }
         )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: feat: 회원 탈퇴 요청 API 추가

## 📄 상세 내용
- [ v ] POST /api/v1/accounts/withdrawal/ 회원 탈퇴 요청 API 구현
- [ v ] 탈퇴 사유(reason) 및 상세 사유(reason_detail) 저장 (Withdrawal 생성)
- [ v ] 탈퇴 요청 시 사용자 비활성화(is_active=False) 처리 + 중복 요청 방지(409)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ v ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ v ] 변경 사항에 대한 테스트를 했습니다. (Swagger에서 탈퇴 요청/응답 확인)
