### PR TITLE
Feature/account restore feat: 탈퇴 계정 복구 API 추가

### DIFF
--- a/apps/users/serializers/restore_serializer.py
+++ b/apps/users/serializers/restore_serializer.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class RestoreSerializer(serializers.Serializer[Any]):
+    email_token = serializers.CharField(allow_blank=False)
+
+
+class RestoreSuccessSerializer(serializers.Serializer[Any]):
+    detail = serializers.CharField()
+
+
+class RestoreErrorDetailSerializer(serializers.Serializer[Any]):
+    error_detail = serializers.CharField()

--- a/apps/users/tests/test_restore.py
+++ b/apps/users/tests/test_restore.py
@@ -1,0 +1,48 @@
+from datetime import date, timedelta
+from typing import Any
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.users.models.withdrawal import Withdrawal
+
+User = get_user_model()
+
+
+class RestoreAPITest(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/accounts/restore/"
+
+    @patch("apps.users.views.restore_view.delete_email_token")
+    @patch("apps.users.views.restore_view.get_email_by_token")
+    def test_restore_success(self, mock_get_email: Any, mock_delete_token: Any) -> None:
+        mock_get_email.return_value = "withdrawn@example.com"
+        email_token = "test-token"
+
+        user = User.objects.create(
+            email="withdrawn@example.com",
+            nickname="nick",
+            name="테스트",
+            phone_number="01012345678",
+            birthday=date(1990, 1, 1),
+            gender="M",
+            is_active=False,
+        )
+        Withdrawal.objects.create(
+            user=user,
+            due_date=date.today() + timedelta(days=7),
+        )
+
+        res = self.client.post(self.url, data={"email_token": email_token}, format="json")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()["detail"], "계정복구가 완료되었습니다.")
+
+        user.refresh_from_db()
+        self.assertTrue(user.is_active)
+        self.assertFalse(Withdrawal.objects.filter(user=user).exists())
+
+        mock_delete_token.assert_called_once_with(email_token)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -10,6 +10,7 @@ from apps.users.views.login_view import LoginAPIView, LogoutAPIView
 from apps.users.views.me import MeView
 from apps.users.views.password_view import ChangePasswordAPIView, FindPasswordAPIView
 from apps.users.views.profile_image_view import ProfileImageView
+from apps.users.views.restore_view import RestoreAPIView
 from apps.users.views.sign_up_view import SignUpAPIView, SignupNicknameCheckAPIView
 from apps.users.views.sms_verification_view import (
     SendSmsVerificationAPIView,
@@ -43,4 +44,5 @@ urlpatterns = [
     # 휴대폰 번호 변경
     path("change-phone/", ChangePhoneView.as_view(), name="change-phone"),
     path("withdrawal/", WithdrawalAPIView.as_view(), name="withdrawal"),
+    path("restore/", RestoreAPIView.as_view(), name="restore"),
 ]

--- a/apps/users/views/restore_view.py
+++ b/apps/users/views/restore_view.py
@@ -1,0 +1,66 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.models.withdrawal import Withdrawal
+from apps.users.serializers.restore_serializer import (
+    RestoreErrorDetailSerializer,
+    RestoreSerializer,
+    RestoreSuccessSerializer,
+)
+from apps.users.utils.redis_utils import delete_email_token, get_email_by_token
+
+User = get_user_model()
+
+
+class RestoreAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        tags=["accounts"],
+        summary="탈퇴 계정 복구 API",
+        request=RestoreSerializer,
+        responses={
+            200: RestoreSuccessSerializer,
+            404: RestoreErrorDetailSerializer,
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = RestoreSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        email_token = serializer.validated_data["email_token"]
+        email = get_email_by_token(email_token)
+
+        if not email:
+            return Response({"error_detail": "유효하지 않은 인증 토큰입니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        user = User.objects.filter(email=email).first()
+
+        if not user:
+            return Response({"error_detail": "복구할 계정을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        withdrawal = Withdrawal.objects.filter(user=user).first()
+
+        if not withdrawal:
+            return Response({"error_detail": "복구할 탈퇴 계정을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        if withdrawal.due_date < date.today():
+            return Response(
+                {"error_detail": "복구 가능 기간이 만료되었습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        with transaction.atomic():
+            user.is_active = True
+            user.save(update_fields=["is_active"])
+            withdrawal.delete()
+            delete_email_token(email_token)
+
+        return Response({"detail": "계정복구가 완료되었습니다."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 탈퇴 계정 복구 API 구현 및 스키마/테스트 추가

## 📄 상세 내용
- [ v ] POST /api/v1/accounts/restore/ 탈퇴 계정 복구 API 구현
        : 이메일 토큰으로 이메일 조회 → 유저/탈퇴내역 확인 → 복구 가능 기간 체크 → is_active 활성화 및 Withdrawal 삭제
- [ v ] Restore API 테스트 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ v ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ v ] 변경 사항에 대한 테스트를 했습니다. (apps.users.tests.test_restore)
