### PR TITLE
[feature/admin-exam-deployment-detail] ✨ feat : 어드민 배포 상세 조회 API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ make logs django # Docker django service 로그만 확인
 USE_EXAM_MOCK=true
 ```
 
-테스트는 환경에 영향받지 않도록 `override_settings(USE_EXAM_MOCK=False)`로 고정되어 있습니다.
+환경변수를 켠 경우에도 테스트는 환경에 영향받지 않도록 `override_settings(USE_EXAM_MOCK=False)`로 고정합니다.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ make logs django # Docker django service 로그만 확인
    - `make fetch` - 원격(origin) 최신 내역 가져오기
    - `make sync-develop` - 원격 최신 내역 가져오기 + develop 브랜치로 이동 + pull develop 브랜치
    - `make rebase` - 로컬 develop 기준으로 리베이스
+
+## Mock 응답 설정
+
+개발 편의를 위해 환경변수로 mock 응답을 사용할 수 있습니다.
+
+- 환경변수: `USE_EXAM_MOCK`
+  - `true`  → mock 데이터 반환
+  - `false` → DB 조회 결과 반환 (기본값)
+
+로컬에서 사용 예시:
+
+```bash
+USE_EXAM_MOCK=true
+```
+
+테스트는 환경에 영향받지 않도록 `override_settings(USE_EXAM_MOCK=False)`로 고정되어 있습니다.

--- a/apps/courses/models/cohort_students.py
+++ b/apps/courses/models/cohort_students.py
@@ -7,6 +7,7 @@ from .cohorts import Cohort
 
 class CohortStudent(TimeStampModel):
     id = models.BigAutoField(primary_key=True)
+    objects: models.Manager["CohortStudent"] = models.Manager()
 
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
 from apps.exams.views.admin_exam_delete_views import AdminExamDeleteAPIView
+from apps.exams.views.admin_exam_deployment_detail_views import (
+    AdminExamDeploymentDetailAPIView,
+)
 from apps.exams.views.admin_exam_deployment_status_views import (
     AdminExamDeploymentStatusAPIView,
 )
@@ -23,6 +26,11 @@ urlpatterns = [
         name="admin-exam-question-delete",
     ),
     path("exams/deployments/", AdminExamDeploymentCreateAPIView.as_view(), name="admin-exam-deployment-create"),
+    path(
+        "exams/deployments/<int:deployment_id>/",
+        AdminExamDeploymentDetailAPIView.as_view(),
+        name="admin-exam-deployment-detail",
+    ),
     path(
         "exams/deployments/<int:deployment_id>/status/",
         AdminExamDeploymentStatusAPIView.as_view(),

--- a/apps/exams/constants.py
+++ b/apps/exams/constants.py
@@ -4,3 +4,83 @@ from enum import Enum
 class ExamStatus(str, Enum):
     CLOSED = "closed"
     ACTIVATED = "activated"
+
+
+class ErrorMessages(str, Enum):
+    # 400
+    INVALID_CHECK_CODE_REQUEST = "응시 코드가 일치하지 않습니다."
+    INVALID_EXAM_SESSION = "유효하지 않은 시험 응시 세션입니다."
+    INVALID_EXAM_CREATE_REQUEST = "유효하지 않은 시험 생성 요청입니다."
+    INVALID_EXAM_LIST_REQUEST = "유효하지 않은 조회 요청입니다."
+    INVALID_EXAM_UPDATE_REQUEST = "유효하지 않은 요청 데이터입니다."
+    INVALID_EXAM_DELETE_REQUEST = "유효하지 않은 요청입니다."
+    INVALID_QUESTION_CREATE_REQUEST = "유효하지 않은 문제 등록 데이터입니다."
+    INVALID_QUESTION_UPDATE_REQUEST = "유효하지 않은 문제 수정 데이터입니다."
+    INVALID_QUESTION_DELETE_REQUEST = "유효하지 않은 문제 삭제 요청입니다."
+    INVALID_DEPLOYMENT_CREATE_REQUEST = "유효하지 않은 배포 생성 요청입니다."
+    INVALID_DEPLOYMENT_DETAIL_REQUEST = "유효하지 않은 배포 상세 조회 요청입니다."
+    INVALID_DEPLOYMENT_UPDATE_REQUEST = "유효하지 않은 배포 수정 요청입니다."
+    INVALID_DEPLOYMENT_STATUS_REQUEST = "유효하지 않은 배포 상태 요청입니다."
+    INVALID_DEPLOYMENT_DELETE_REQUEST = "유효하지 않은 배포 삭제 요청입니다."
+    INVALID_SUBMISSION_LIST_REQUEST = "유효하지 않은 조회 요청입니다."
+    INVALID_SUBMISSION_DETAIL_REQUEST = "유효하지 않은 상세 조회 요청입니다."
+    INVALID_SUBMISSION_DELETE_REQUEST = "유효하지 않은 응시 내역 삭제 요청입니다."
+
+    # 401
+    UNAUTHORIZED = "자격 인증 데이터가 제공되지 않았습니다."
+
+    # 403
+    FORBIDDEN = "권한이 없습니다."
+    NO_EXAM_STAFF_PERMISSION = "쪽지시험 관리 권한이 없습니다."
+    NO_EXAM_LIST_PERMISSION = "쪽지시험 목록 조회 권한이 없습니다."
+    NO_EXAM_CREATE_PERMISSION = "쪽지시험 생성 권한이 없습니다."
+    NO_EXAM_UPDATE_PERMISSION = "쪽지시험 수정 권한이 없습니다."
+    NO_EXAM_DELETE_PERMISSION = "쪽지시험 삭제 권한이 없습니다."
+    NO_QUESTION_CREATE_PERMISSION = "쪽지시험 문제 등록 권한이 없습니다."
+    NO_QUESTION_UPDATE_PERMISSION = "쪽지시험 문제 수정 권한이 없습니다."
+    NO_QUESTION_DELETE_PERMISSION = "쪽지시험 문제 삭제 권한이 없습니다."
+    NO_DEPLOYMENT_CREATE_PERMISSION = "쪽지시험 배포 생성 권한이 없습니다."
+    NO_DEPLOYMENT_DETAIL_PERMISSION = "쪽지시험 배포 상세 조회 권한이 없습니다."
+    NO_DEPLOYMENT_LIST_PERMISSION = "쪽지시험 배포 목록 조회 권한이 없습니다."
+    NO_DEPLOYMENT_UPDATE_PERMISSION = "쪽지시험 배포 수정 권한이 없습니다."
+    NO_DEPLOYMENT_STATUS_PERMISSION = "쪽지시험 배포 상태 변경 권한이 없습니다."
+    NO_DEPLOYMENT_DELETE_PERMISSION = "배포 삭제 권한이 없습니다."
+    NO_SUBMISSION_LIST_PERMISSION = "쪽지시험 응시 내역 조회 권한이 없습니다."
+    NO_SUBMISSION_DETAIL_PERMISSION = "쪽지시험 응시 상세 조회 권한이 없습니다."
+    NO_SUBMISSION_DELETE_PERMISSION = "쪽지시험 응시 내역 삭제 권한이 없습니다."
+    NO_EXAM_TAKE_PERMISSION = "시험에 응시할 권한이 없습니다."
+
+    # 404
+    EXAM_NOT_FOUND = "해당 시험 정보를 찾을 수 없습니다."
+    EXAM_ADMIN_NOT_FOUND = "해당 쪽지시험 정보를 찾을 수 없습니다."
+    EXAM_UPDATE_NOT_FOUND = "수정할 쪽지시험 정보를 찾을 수 없습니다."
+    EXAM_DELETE_NOT_FOUND = "삭제하려는 쪽지시험 정보를 찾을 수 없습니다."
+    QUESTION_NOT_FOUND = "삭제할 문제 정보를 찾을 수 없습니다."
+    QUESTION_UPDATE_NOT_FOUND = "수정하려는 문제 정보를 찾을 수 없습니다."
+    DEPLOYMENT_NOT_FOUND = "해당 배포 정보를 찾을 수 없습니다."
+    DEPLOYMENT_TARGET_NOT_FOUND = "배포 대상 과정-기수 또는 시험 정보를 찾을 수 없습니다."
+    DEPLOYMENT_UPDATE_NOT_FOUND = "수정할 배포 정보를 찾을 수 없습니다."
+    DEPLOYMENT_DELETE_NOT_FOUND = "삭제할 배포 정보를 찾을 수 없습니다."
+    SUBMISSION_LIST_NOT_FOUND = "조회된 응시 내역이 없습니다."
+    SUBMISSION_DETAIL_NOT_FOUND = "해당 응시 내역을 찾을 수 없습니다."
+    USER_NOT_FOUND = "사용자 정보를 찾을 수 없습니다."
+
+    # 409
+    EXAM_CONFLICT = "동일한 이름의 시험이 이미 존재합니다."
+    EXAM_UPDATE_CONFLICT = "동일한 이름의 쪽지시험이 이미 존재합니다."
+    EXAM_DELETE_CONFLICT = "쪽지시험 삭제 중 충돌이 발생했습니다."
+    QUESTION_CREATE_CONFLICT = "해당 쪽지시험에 등록 가능한 문제 수 또는 총 배점을 초과했습니다."
+    QUESTION_UPDATE_CONFLICT = "시험 문제 수 제한 또는 총 배점을 초과하여 문제를 수정할 수 없습니다."
+    QUESTION_DELETE_CONFLICT = "쪽지시험 문제 삭제 처리 중 충돌이 발생했습니다."
+    DUPLICATE_DEPLOYMENT = "동일한 조건의 배포가 이미 존재합니다."
+    DEPLOYMENT_CONFLICT = "배포 상태 변경 중 충돌이 발생했습니다."
+    DEPLOYMENT_DELETE_CONFLICT = "배포 삭제 처리 중 충돌이 발생했습니다."
+    SUBMISSION_ALREADY_SUBMITTED = "이미 제출된 시험입니다."
+    SUBMISSION_DELETE_CONFLICT = "응시 내역 삭제 처리 중 충돌이 발생했습니다."
+
+    # 410
+    EXAM_CLOSED = "시험이 종료되었습니다."
+    EXAM_ALREADY_CLOSED = "시험이 이미 종료되었습니다."
+
+    # 423
+    EXAM_NOT_AVAILABLE = "아직 응시할 수 없습니다."

--- a/apps/exams/serializers/admin_exam_deployment_detail_serializers.py
+++ b/apps/exams/serializers/admin_exam_deployment_detail_serializers.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamDeploymentCourseSerializer(serializers.Serializer[Any]):
+    """배포 상세 조회 코스 정보 스키마."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    tag = serializers.CharField()
+
+
+class AdminExamDeploymentCohortSerializer(serializers.Serializer[Any]):
+    """배포 상세 조회 기수 정보 스키마."""
+
+    id = serializers.IntegerField()
+    number = serializers.IntegerField()
+    display = serializers.CharField()
+    course = AdminExamDeploymentCourseSerializer()
+
+
+class AdminExamDeploymentSubjectSerializer(serializers.Serializer[Any]):
+    """배포 상세 조회 과목 정보 스키마."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class AdminExamDeploymentQuestionSerializer(serializers.Serializer[Any]):
+    """배포 상세 조회 문항 정보 스키마."""
+
+    question_id = serializers.IntegerField()
+    type = serializers.CharField()
+    question = serializers.CharField()
+    prompt = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    blank_count = serializers.IntegerField()
+    options = serializers.ListField(child=serializers.CharField(), required=False, allow_null=True)
+    point = serializers.IntegerField()
+
+
+class AdminExamDeploymentExamSerializer(serializers.Serializer[Any]):
+    """배포 상세 조회 시험 정보 스키마."""
+
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    thumbnail_img_url = serializers.CharField()
+    questions = AdminExamDeploymentQuestionSerializer(many=True)
+
+
+class AdminExamDeploymentDetailResponseSerializer(serializers.Serializer[Any]):
+    """어드민 쪽지시험 배포 상세 조회 응답 스키마."""
+
+    id = serializers.IntegerField()
+    exam_access_url = serializers.CharField()
+    access_code = serializers.CharField()
+    cohort = AdminExamDeploymentCohortSerializer()
+    submit_count = serializers.IntegerField()
+    not_submitted_count = serializers.IntegerField()
+    duration_time = serializers.IntegerField()
+    open_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    close_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    exam = AdminExamDeploymentExamSerializer()
+    subject = AdminExamDeploymentSubjectSerializer()

--- a/apps/exams/serializers/admin_exam_deployment_detail_serializers.py
+++ b/apps/exams/serializers/admin_exam_deployment_detail_serializers.py
@@ -45,7 +45,6 @@ class AdminExamDeploymentExamSerializer(serializers.Serializer[Any]):
     id = serializers.IntegerField()
     title = serializers.CharField()
     thumbnail_img_url = serializers.CharField()
-    questions = AdminExamDeploymentQuestionSerializer(many=True)
 
 
 class AdminExamDeploymentDetailResponseSerializer(serializers.Serializer[Any]):

--- a/apps/exams/services/admin_exam_deployment_detail_service.py
+++ b/apps/exams/services/admin_exam_deployment_detail_service.py
@@ -21,10 +21,6 @@ def get_exam_deployment_detail(deployment_id: int) -> dict[str, Any]:
 
     course = deployment.cohort.course
     cohort_display = f"{course.name} {deployment.cohort.number}기"
-    questions = deployment.questions_snapshot_json
-    if not isinstance(questions, list):
-        questions = []
-
     return {
         "id": deployment.id,
         "access_code": deployment.access_code,
@@ -44,7 +40,6 @@ def get_exam_deployment_detail(deployment_id: int) -> dict[str, Any]:
             "id": deployment.exam.id,
             "title": deployment.exam.title,
             "thumbnail_img_url": deployment.exam.thumbnail_img_url,
-            "questions": questions,
         },
         "subject": {
             "id": deployment.exam.subject.id,

--- a/apps/exams/services/admin_exam_deployment_detail_service.py
+++ b/apps/exams/services/admin_exam_deployment_detail_service.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from apps.courses.models.cohort_students import CohortStudent
+from apps.exams.models import ExamDeployment
+
+
+class ExamDeploymentDetailNotFoundError(Exception):
+    """배포 상세 조회 대상이 없을 때 발생."""
+
+
+def get_exam_deployment_detail(deployment_id: int) -> dict[str, Any]:
+    deployment = (
+        ExamDeployment.objects.select_related("exam__subject", "cohort__course").filter(id=deployment_id).first()
+    )
+    if not deployment:
+        raise ExamDeploymentDetailNotFoundError
+
+    submitted_count = deployment.submissions.values("submitter_id").distinct().count()
+    total_students = CohortStudent.objects.filter(cohort_id=deployment.cohort_id).count()
+    not_submitted_count = max(total_students - submitted_count, 0)
+
+    course = deployment.cohort.course
+    cohort_display = f"{course.name} {deployment.cohort.number}기"
+    questions = deployment.questions_snapshot_json
+    if not isinstance(questions, list):
+        questions = []
+
+    return {
+        "id": deployment.id,
+        "access_code": deployment.access_code,
+        "cohort": {
+            "id": deployment.cohort.id,
+            "number": deployment.cohort.number,
+            "display": cohort_display,
+            "course": {"id": course.id, "name": course.name, "tag": course.tag},
+        },
+        "submit_count": submitted_count,
+        "not_submitted_count": not_submitted_count,
+        "duration_time": deployment.duration_time,
+        "open_at": deployment.open_at,
+        "close_at": deployment.close_at,
+        "created_at": deployment.created_at,
+        "exam": {
+            "id": deployment.exam.id,
+            "title": deployment.exam.title,
+            "thumbnail_img_url": deployment.exam.thumbnail_img_url,
+            "questions": questions,
+        },
+        "subject": {
+            "id": deployment.exam.subject.id,
+            "name": deployment.exam.subject.title,
+        },
+    }

--- a/apps/exams/tests/test_admin_exam_deployment_detail_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_detail_views.py
@@ -1,0 +1,193 @@
+from datetime import date, datetime, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohort_students import CohortStudent
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion, ExamSubmission
+from apps.users.models import User
+
+
+class AdminExamDeploymentDetailAPITest(TestCase):
+    """어드민 쪽지시험 배포 상세 조회 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=11,
+            max_student=30,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.question = ExamQuestion.objects.create(
+            exam=self.exam,
+            question="OX 문제",
+            type=ExamQuestion.TypeChoices.OX,
+            answer="O",
+            point=5,
+            explanation="",
+        )
+        self.deployment = ExamDeployment.objects.create(
+            exam=self.exam,
+            cohort=self.cohort,
+            duration_time=45,
+            access_code="ACCESSCODE",
+            open_at=timezone.make_aware(datetime(2025, 3, 2, 10, 0, 0)),
+            close_at=timezone.make_aware(datetime(2025, 3, 2, 12, 0, 0)),
+            questions_snapshot_json=[
+                {
+                    "question_id": self.question.id,
+                    "type": self.question.type,
+                    "question": self.question.question,
+                    "prompt": self.question.prompt,
+                    "blank_count": self.question.blank_count,
+                    "options": None,
+                    "point": self.question.point,
+                }
+            ],
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+        )
+        self.student1 = User.objects.create_user(
+            email="student1@example.com",
+            password="password123",
+            name="수강생1",
+            nickname="수강생1",
+            phone_number="01011114444",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 3),
+            role=User.Role.STUDENT,
+        )
+        self.student2 = User.objects.create_user(
+            email="student2@example.com",
+            password="password123",
+            name="수강생2",
+            nickname="수강생2",
+            phone_number="01011115555",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 4),
+            role=User.Role.STUDENT,
+        )
+        self.student3 = User.objects.create_user(
+            email="student3@example.com",
+            password="password123",
+            name="수강생3",
+            nickname="수강생3",
+            phone_number="01011116666",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 5),
+            role=User.Role.STUDENT,
+        )
+        CohortStudent.objects.create(user=self.student1, cohort=self.cohort)
+        CohortStudent.objects.create(user=self.student2, cohort=self.cohort)
+        CohortStudent.objects.create(user=self.student3, cohort=self.cohort)
+        ExamSubmission.objects.create(
+            submitter=self.student1,
+            deployment=self.deployment,
+            started_at=timezone.now(),
+            cheating_count=0,
+            answers_json={},
+            score=0,
+            correct_answer_count=0,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_get_deployment_detail(self) -> None:
+        response = self.client.get(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["id"], self.deployment.id)
+        self.assertEqual(data["access_code"], "ACCESSCODE")
+        self.assertEqual(data["submit_count"], 1)
+        self.assertEqual(data["not_submitted_count"], 2)
+        self.assertEqual(data["exam"]["id"], self.exam.id)
+        self.assertEqual(data["subject"]["id"], self.subject.id)
+        self.assertEqual(len(data["exam"]["questions"]), 1)
+        self.assertEqual(
+            data["exam_access_url"],
+            f"http://testserver/api/v1/exams/deployments/{self.deployment.id}",
+        )
+
+    def test_returns_400_when_invalid_deployment_id(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/0/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "유효하지 않은 배포 상세 조회 요청입니다.")
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.get(f"/api/v1/admin/exams/deployments/{self.deployment.id}/")
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+
+    def test_returns_403_for_non_staff(self) -> None:
+        response = self.client.get(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
+            headers=self._auth_headers(self.normal_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["detail"], "쪽지시험 관리 권한이 없습니다.")
+
+    def test_returns_404_when_deployment_missing(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/9999/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], "해당 배포 정보를 찾을 수 없습니다.")

--- a/apps/exams/tests/test_admin_exam_deployment_detail_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_detail_views.py
@@ -171,7 +171,7 @@ class AdminExamDeploymentDetailAPITest(TestCase):
 
         self.assertEqual(response.status_code, 401)
         data = response.json()
-        self.assertEqual(data["detail"], "자격 인증데이터(authentication credentials)가 제공되지 않았습니다.")
+        self.assertEqual(data["detail"], ErrorMessages.UNAUTHORIZED.value)
 
     def test_returns_403_for_non_staff(self) -> None:
         response = self.client.get(
@@ -181,7 +181,7 @@ class AdminExamDeploymentDetailAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         data = response.json()
-        self.assertEqual(data["detail"], "쪽지시험 관리 권한이 없습니다.")
+        self.assertEqual(data["detail"], ErrorMessages.NO_DEPLOYMENT_DETAIL_PERMISSION.value)
 
     def test_returns_404_when_deployment_missing(self) -> None:
         response = self.client.get(

--- a/apps/exams/tests/test_admin_exam_deployment_detail_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_detail_views.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from rest_framework_simplejwt.tokens import AccessToken
 
@@ -13,6 +13,7 @@ from apps.exams.models import Exam, ExamDeployment, ExamQuestion, ExamSubmission
 from apps.users.models import User
 
 
+@override_settings(USE_EXAM_MOCK=False)
 class AdminExamDeploymentDetailAPITest(TestCase):
     """어드민 쪽지시험 배포 상세 조회 API 테스트."""
 

--- a/apps/exams/tests/test_admin_exam_deployment_detail_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_detail_views.py
@@ -9,6 +9,7 @@ from apps.courses.models.cohorts import Cohort
 from apps.courses.models.courses import Course
 from apps.courses.models.subjects import Subject
 from apps.exams.models import Exam, ExamDeployment, ExamQuestion, ExamSubmission
+from apps.exams.constants import ErrorMessages
 from apps.users.models import User
 
 
@@ -149,7 +150,6 @@ class AdminExamDeploymentDetailAPITest(TestCase):
         self.assertEqual(data["not_submitted_count"], 2)
         self.assertEqual(data["exam"]["id"], self.exam.id)
         self.assertEqual(data["subject"]["id"], self.subject.id)
-        self.assertEqual(len(data["exam"]["questions"]), 1)
         self.assertEqual(
             data["exam_access_url"],
             f"http://testserver/api/v1/exams/deployments/{self.deployment.id}",
@@ -163,7 +163,7 @@ class AdminExamDeploymentDetailAPITest(TestCase):
 
         self.assertEqual(response.status_code, 400)
         data = response.json()
-        self.assertEqual(data["error_detail"], "유효하지 않은 배포 상세 조회 요청입니다.")
+        self.assertEqual(data["error_detail"], ErrorMessages.INVALID_DEPLOYMENT_DETAIL_REQUEST.value)
 
     def test_returns_401_when_unauthenticated(self) -> None:
         response = self.client.get(f"/api/v1/admin/exams/deployments/{self.deployment.id}/")
@@ -190,4 +190,4 @@ class AdminExamDeploymentDetailAPITest(TestCase):
 
         self.assertEqual(response.status_code, 404)
         data = response.json()
-        self.assertEqual(data["error_detail"], "해당 배포 정보를 찾을 수 없습니다.")
+        self.assertEqual(data["error_detail"], ErrorMessages.DEPLOYMENT_NOT_FOUND.value)

--- a/apps/exams/tests/test_admin_exam_deployment_detail_views.py
+++ b/apps/exams/tests/test_admin_exam_deployment_detail_views.py
@@ -8,8 +8,8 @@ from apps.courses.models.cohort_students import CohortStudent
 from apps.courses.models.cohorts import Cohort
 from apps.courses.models.courses import Course
 from apps.courses.models.subjects import Subject
-from apps.exams.models import Exam, ExamDeployment, ExamQuestion, ExamSubmission
 from apps.exams.constants import ErrorMessages
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion, ExamSubmission
 from apps.users.models import User
 
 

--- a/apps/exams/views/admin_exam_deployment_detail_views.py
+++ b/apps/exams/views/admin_exam_deployment_detail_views.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.exams.constants import ErrorMessages
 from apps.exams.permissions import IsExamStaff
 from apps.exams.serializers.admin_exam_deployment_detail_serializers import (
     AdminExamDeploymentDetailResponseSerializer,
@@ -41,7 +42,7 @@ class AdminExamDeploymentDetailAPIView(APIView):
     def get(self, request: Request, deployment_id: int) -> Response:
         if deployment_id <= 0:
             return Response(
-                {"error_detail": "유효하지 않은 배포 상세 조회 요청입니다."},
+                {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_DETAIL_REQUEST.value},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -49,7 +50,7 @@ class AdminExamDeploymentDetailAPIView(APIView):
             payload = get_exam_deployment_detail(deployment_id)
         except ExamDeploymentDetailNotFoundError:
             return Response(
-                {"error_detail": "해당 배포 정보를 찾을 수 없습니다."},
+                {"error_detail": ErrorMessages.DEPLOYMENT_NOT_FOUND.value},
                 status=status.HTTP_404_NOT_FOUND,
             )
 

--- a/apps/exams/views/admin_exam_deployment_detail_views.py
+++ b/apps/exams/views/admin_exam_deployment_detail_views.py
@@ -1,0 +1,60 @@
+from django.urls import reverse
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.permissions import IsExamStaff
+from apps.exams.serializers.admin_exam_deployment_detail_serializers import (
+    AdminExamDeploymentDetailResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin_exam_deployment_detail_service import (
+    ExamDeploymentDetailNotFoundError,
+    get_exam_deployment_detail,
+)
+
+
+class AdminExamDeploymentDetailAPIView(APIView):
+    """어드민 쪽지시험 배포 상세 조회 API."""
+
+    permission_classes = [IsAuthenticated, IsExamStaff]
+    serializer_class = AdminExamDeploymentDetailResponseSerializer
+
+    @extend_schema(
+        tags=["admin_exams"],
+        summary="어드민 쪽지시험 배포 상세 조회 API",
+        description="""
+        스태프/관리자가 쪽지시험 배포 상세 정보를 조회합니다.
+        시험 정보, 배포 정보, 응시 통계를 반환합니다.
+        """,
+        responses={
+            200: AdminExamDeploymentDetailResponseSerializer,
+            400: OpenApiResponse(ErrorResponseSerializer, description="유효하지 않은 요청"),
+            401: OpenApiResponse(ErrorResponseSerializer, description="인증 실패"),
+            403: OpenApiResponse(ErrorResponseSerializer, description="배포 조회 권한 없음"),
+            404: OpenApiResponse(ErrorResponseSerializer, description="배포 정보 없음"),
+        },
+    )
+    def get(self, request: Request, deployment_id: int) -> Response:
+        if deployment_id <= 0:
+            return Response(
+                {"error_detail": "유효하지 않은 배포 상세 조회 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            payload = get_exam_deployment_detail(deployment_id)
+        except ExamDeploymentDetailNotFoundError:
+            return Response(
+                {"error_detail": "해당 배포 정보를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        access_url = request.build_absolute_uri(reverse("exams:take-exam", kwargs={"deployment_id": deployment_id}))
+        payload["exam_access_url"] = access_url
+
+        serializer = self.serializer_class(payload)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/exams/views/admin_exam_deployment_detail_views.py
+++ b/apps/exams/views/admin_exam_deployment_detail_views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import reverse
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
@@ -45,6 +46,41 @@ class AdminExamDeploymentDetailAPIView(APIView):
                 {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_DETAIL_REQUEST.value},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        if settings.USE_EXAM_MOCK:
+            access_url = request.build_absolute_uri(reverse("exams:take-exam", kwargs={"deployment_id": deployment_id}))
+            payload = {
+                "id": deployment_id,
+                "exam_access_url": access_url,
+                "access_code": "A7Bd9K",
+                "cohort": {
+                    "id": 11,
+                    "number": 11,
+                    "display": "백엔드 11기",
+                    "course": {
+                        "id": 12,
+                        "name": "백엔드",
+                        "tag": "BE",
+                    },
+                },
+                "submit_count": 58,
+                "not_submitted_count": 12,
+                "duration_time": 45,
+                "open_at": "2025-03-02 10:00:00",
+                "close_at": "2025-03-02 12:00:00",
+                "created_at": "2025-03-01 14:20:33",
+                "exam": {
+                    "id": 101,
+                    "title": "Python 기본 문법 테스트",
+                    "thumbnail_img_url": "https://img.com/images/sample.png",
+                },
+                "subject": {
+                    "id": 32,
+                    "name": "Python",
+                },
+            }
+            serializer = self.serializer_class(payload)
+            return Response(serializer.data, status=status.HTTP_200_OK)
 
         try:
             payload = get_exam_deployment_detail(deployment_id)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -239,3 +239,6 @@ AWS_S3_REGION = os.getenv("AWS_S3_REGION", "")
 AWS_S3_ACCESS_KEY_ID = os.getenv("AWS_S3_ACCESS_KEY_ID", "")
 AWS_S3_SECRET_ACCESS_KEY = os.getenv("AWS_S3_SECRET_ACCESS_KEY", "")
 AWS_S3_BUCKET_NAME = os.getenv("AWS_S3_BUCKET_NAME", "")
+
+# Data Using Settings
+USE_EXAM_MOCK = os.getenv("USE_EXAM_MOCK", "false").lower() == "true"


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 쪽지시험 배포 상세 조회 API 구현 및 mypy 정리

## 📄 상세 내용
- [x] 배포 상세 조회 API 추가  
  - `apps/exams/views/admin_exam_deployment_detail_views.py`
    - `AdminExamDeploymentDetailAPIView.get()` 구현 (응답 직렬화)
  - `apps/exams/services/admin_exam_deployment_detail_service.py`
    - `get_exam_deployment_detail()` 구현 (참여/미참여 집계, 스냅샷 구성)
  - `apps/exams/serializers/admin_exam_deployment_detail_serializers.py`
    - `AdminExamDeploymentDetailResponseSerializer`
    - `AdminExamDeploymentExamSerializer`
    - `AdminExamDeploymentQuestionSerializer`
- [x] 라우팅 추가  
  - `apps/exams/admin_urls.py`에 `exams/deployments/<int:deployment_id>/` 등록
- [x] 테스트 추가  
  - `apps/exams/tests/test_admin_exam_deployment_detail_views.py`
    - 상세 조회/401/403/404/400 케이스 추가
- [x] mypy 정리  
  - `apps/courses/models/cohort_students.py` 매니저 선언
  - `apps/exams/views/exam_list.py`, `apps/users/services/course_service.py` 등 불필요한 `type: ignore` 제거

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
