### PR TITLE
[update/custom-jwt-auth] feat: 탈퇴 계정 API 접근 차단을 위한 JWT 인증 개선

### DIFF
--- a/apps/users/authentication.py
+++ b/apps/users/authentication.py
@@ -1,10 +1,11 @@
-from rest_framework_simplejwt.authentication import JWTAuthentication
+from typing import Any
+
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
 
 class ActiveUserJWTAuthentication(JWTAuthentication):
-
-    def get_user(self, validated_token):
+    def get_user(self, validated_token: Any) -> object:  # type: ignore[override]
         user = super().get_user(validated_token)
 
         if not getattr(user, "is_active", True):

--- a/apps/users/authentication.py
+++ b/apps/users/authentication.py
@@ -1,0 +1,16 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class ActiveUserJWTAuthentication(JWTAuthentication):
+
+    def get_user(self, validated_token):
+        user = super().get_user(validated_token)
+
+        if not getattr(user, "is_active", True):
+            raise AuthenticationFailed(
+                detail={"error_detail": {"detail": "비활성화된 계정입니다."}},
+                code="inactive_user",
+            )
+
+        return user

--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -12,3 +12,7 @@ class WithdrawalResponseSerializer(serializers.Serializer):  # type: ignore[type
     message = serializers.CharField()
     due_date = serializers.DateField()
     reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)
+
+
+class ErrorDetailSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    error_detail = serializers.CharField()

--- a/apps/users/tests/test_custom_jwt_auth.py
+++ b/apps/users/tests/test_custom_jwt_auth.py
@@ -1,9 +1,11 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework import status
-from datetime import date
-from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
+
 
 class CustomJwtAuthTests(TestCase):
     client: APIClient
@@ -31,7 +33,7 @@ class CustomJwtAuthTests(TestCase):
         access = str(RefreshToken.for_user(self.user).access_token)
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
 
-    def test_inactive_user_cannot_access_me(self):
+    def test_inactive_user_cannot_access_me(self) -> None:
         me_url = "/api/v1/accounts/me/"
         response = self.client.get(me_url)
 

--- a/apps/users/tests/test_custom_jwt_auth.py
+++ b/apps/users/tests/test_custom_jwt_auth.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from rest_framework import status
+from datetime import date
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+class CustomJwtAuthTests(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.withdrawal_url = "/api/v1/accounts/withdrawal/"
+
+        User = get_user_model()
+        self.email = "withdrawal_test@example.com"
+        self.password = "Testpass123!"
+        self.user = User.objects.create_user(
+            email=self.email,
+            password=self.password,
+            birthday=date(2000, 1, 1),
+            phone_number="01012345678",
+            name="테스터",
+            nickname="tester",
+            gender="male",
+        )
+
+        self.user.is_active = False
+        self.user.save()
+
+        access = str(RefreshToken.for_user(self.user).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+
+    def test_inactive_user_cannot_access_me(self):
+        me_url = "/api/v1/accounts/me/"
+        response = self.client.get(me_url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -174,12 +174,10 @@ CORS_ALLOW_HEADERS = [
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
-
     # NOTE: DEFAULT_AUTHENTICATION_CLASSES를 JWTAuthentication -> ActiveUserJWTAuthentication으로 변경.
     #       기존 JWTAuthentication만 사용 시, is_active=False(탈퇴/비활성) 계정도 유효한 access 토큰으로 IsAuthenticated를 통과해
     #       API 호출이 가능할 수 있음. 이를 방지하기 위해 커스텀 인증에서 매 요청마다 is_active를 검사해 인증 단계에서 차단한다.
     "DEFAULT_AUTHENTICATION_CLASSES": ("apps.users.authentication.ActiveUserJWTAuthentication",),
-
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -170,15 +170,21 @@ CORS_ALLOW_HEADERS = [
     "x-requested-with",
 ]
 
-# drf 관련 설정
+# DRF 관련 설정
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
-    "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework_simplejwt.authentication.JWTAuthentication",),
+
+    # NOTE: DEFAULT_AUTHENTICATION_CLASSES를 JWTAuthentication -> ActiveUserJWTAuthentication으로 변경.
+    #       기존 JWTAuthentication만 사용 시, is_active=False(탈퇴/비활성) 계정도 유효한 access 토큰으로 IsAuthenticated를 통과해
+    #       API 호출이 가능할 수 있음. 이를 방지하기 위해 커스텀 인증에서 매 요청마다 is_active를 검사해 인증 단계에서 차단한다.
+    "DEFAULT_AUTHENTICATION_CLASSES": ("apps.users.authentication.ActiveUserJWTAuthentication",),
+
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
 }
+
 
 # drf-spectacular 관련 설정
 SPECTACULAR_SETTINGS = {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -174,9 +174,6 @@ CORS_ALLOW_HEADERS = [
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
-    # NOTE: DEFAULT_AUTHENTICATION_CLASSES를 JWTAuthentication -> ActiveUserJWTAuthentication으로 변경.
-    #       기존 JWTAuthentication만 사용 시, is_active=False(탈퇴/비활성) 계정도 유효한 access 토큰으로 IsAuthenticated를 통과해
-    #       API 호출이 가능할 수 있음. 이를 방지하기 위해 커스텀 인증에서 매 요청마다 is_active를 검사해 인증 단계에서 차단한다.
     "DEFAULT_AUTHENTICATION_CLASSES": ("apps.users.authentication.ActiveUserJWTAuthentication",),
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 탈퇴·비활성 계정(is_active=False)이 유효한 JWT 토큰을 가지고 있어도 API에 접근하지 못하도록 커스텀 JWT 인증을 적용했습니다, 회원 탈퇴 API를 기준으로 매서드를 수정했습니다.

## 📄 상세 내용
- [ v ] SimpleJWT 기반 커스텀 인증 클래스(ActiveUserJWTAuthentication) 추가
- [ v ] DRF 전역 인증 설정을 커스텀 JWT 인증으로 교체하여 매 요청마다 is_active 검사
- [ v ] 비활성 계정 접근 차단을 검증하는 테스트 케이스 추가
- [ v ] 회원탈퇴 API를 명세 기준으로 정렬: DELETE 메서드, 204 No Content, 성공 응답 바디 제거

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- [ v ] config/settings/base.py에서 DRF의 DEFAULT_AUTHENTICATION_CLASSES를 커스텀 JWT 인증(ActiveUserJWTAuthentication)으로 변경했습니다.
## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (custom JWT 인증 테스트 추가)
