### PR TITLE
[feat/exams-admin-deployments-list] 어드민 배포 목록 조회 API 추가 및 스키마 정리

### DIFF
--- a/apps/exams/constants.py
+++ b/apps/exams/constants.py
@@ -18,6 +18,7 @@ class ErrorMessages(str, Enum):
     INVALID_QUESTION_UPDATE_REQUEST = "유효하지 않은 문제 수정 데이터입니다."
     INVALID_QUESTION_DELETE_REQUEST = "유효하지 않은 문제 삭제 요청입니다."
     INVALID_DEPLOYMENT_CREATE_REQUEST = "유효하지 않은 배포 생성 요청입니다."
+    INVALID_DEPLOYMENT_LIST_REQUEST = "유효하지 않은 조회 요청입니다."
     INVALID_DEPLOYMENT_DETAIL_REQUEST = "유효하지 않은 배포 상세 조회 요청입니다."
     INVALID_DEPLOYMENT_UPDATE_REQUEST = "유효하지 않은 배포 수정 요청입니다."
     INVALID_DEPLOYMENT_STATUS_REQUEST = "유효하지 않은 배포 상태 요청입니다."

--- a/apps/exams/serializers/admin/deployments_list.py
+++ b/apps/exams/serializers/admin/deployments_list.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models.exam_deployments import ExamDeployment
+from apps.exams.models.exams import Exam
+
+
+class AdminExamDeploymentCourseSerializer(serializers.ModelSerializer[Course]):
+    class Meta:
+        model = Course
+        fields = ["id", "name", "tag"]
+
+
+class AdminExamDeploymentCohortSerializer(serializers.ModelSerializer[Cohort]):
+    display = serializers.SerializerMethodField()
+    course = AdminExamDeploymentCourseSerializer(read_only=True)
+
+    def get_display(self, obj: Cohort) -> str:
+        return f"{obj.course.name} {obj.number}기"
+
+    class Meta:
+        model = Cohort
+        fields = ["id", "number", "display", "course"]
+
+
+class AdminExamDeploymentSubjectSerializer(serializers.ModelSerializer[Subject]):
+    name = serializers.CharField(source="title")
+
+    class Meta:
+        model = Subject
+        fields = ["id", "name"]
+
+
+class AdminExamDeploymentExamSerializer(serializers.ModelSerializer[Exam]):
+    class Meta:
+        model = Exam
+        fields = ["id", "title", "thumbnail_img_url"]
+
+
+class AdminExamDeploymentListItemSerializer(serializers.ModelSerializer[ExamDeployment]):
+    submit_count = serializers.IntegerField(read_only=True)
+    avg_score = serializers.FloatField(read_only=True)
+    status = serializers.SerializerMethodField()
+    exam = AdminExamDeploymentExamSerializer(read_only=True)
+    subject = AdminExamDeploymentSubjectSerializer(source="exam.subject", read_only=True)
+    cohort = AdminExamDeploymentCohortSerializer(read_only=True)
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+
+    def get_status(self, obj: ExamDeployment) -> str:
+        return obj.status.lower()
+
+    class Meta:
+        model = ExamDeployment
+        fields = [
+            "id",
+            "submit_count",
+            "avg_score",
+            "status",
+            "exam",
+            "subject",
+            "cohort",
+            "created_at",
+        ]

--- a/apps/exams/services/admin/deployments_list.py
+++ b/apps/exams/services/admin/deployments_list.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db.models import Avg, Count, Q, QuerySet
+from django.db.models.functions import Coalesce
+
+from apps.exams.constants import ErrorMessages
+from apps.exams.models import ExamDeployment
+
+
+class InvalidAdminDeploymentListParams(Exception):
+    """어드민 배포 목록 조회 파라미터가 유효하지 않을 때"""
+
+
+@dataclass(frozen=True)
+class AdminDeploymentListParams:
+    search_keyword: Optional[str] = None
+    subject_id: Optional[int] = None
+    cohort_id: Optional[int] = None
+    sort: str = "created_at"
+    order: str = "desc"
+
+
+class AdminDeploymentListService:
+    ALLOWED_SORT = {"created_at", "submit_count", "avg_score"}
+    ALLOWED_ORDER = {"asc", "desc"}
+    DEFAULT_SORT = "created_at"
+    DEFAULT_ORDER = "desc"
+
+    @classmethod
+    def parse_params(
+        cls,
+        *,
+        search_keyword: str | None,
+        subject_id: str | None,
+        cohort_id: str | None,
+        sort: str | None,
+        order: str | None,
+    ) -> AdminDeploymentListParams:
+        sort_v = sort or cls.DEFAULT_SORT
+        order_v = order or cls.DEFAULT_ORDER
+
+        if sort_v not in cls.ALLOWED_SORT or order_v not in cls.ALLOWED_ORDER:
+            raise InvalidAdminDeploymentListParams(ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST.value)
+
+        subject_id_v: int | None = None
+        if subject_id:
+            try:
+                subject_id_v = int(subject_id)
+            except ValueError as exc:
+                raise InvalidAdminDeploymentListParams(ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST.value) from exc
+
+        cohort_id_v: int | None = None
+        if cohort_id:
+            try:
+                cohort_id_v = int(cohort_id)
+            except ValueError as exc:
+                raise InvalidAdminDeploymentListParams(ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST.value) from exc
+
+        return AdminDeploymentListParams(
+            search_keyword=search_keyword or None,
+            subject_id=subject_id_v,
+            cohort_id=cohort_id_v,
+            sort=sort_v,
+            order=order_v,
+        )
+
+    @classmethod
+    def get_queryset(cls, params: AdminDeploymentListParams) -> QuerySet[ExamDeployment]:
+        qs = ExamDeployment.objects.select_related(
+            "exam__subject",
+            "cohort__course",
+        ).annotate(
+            submit_count=Count("submissions", distinct=True),
+            avg_score=Coalesce(Avg("submissions__score"), 0.0),
+        )
+
+        if params.search_keyword:
+            qs = qs.filter(Q(exam__title__icontains=params.search_keyword))
+
+        if params.subject_id is not None:
+            qs = qs.filter(exam__subject_id=params.subject_id)
+
+        if params.cohort_id is not None:
+            qs = qs.filter(cohort_id=params.cohort_id)
+
+        prefix = "-" if params.order == "desc" else ""
+        return qs.order_by(f"{prefix}{params.sort}")

--- a/apps/exams/tests/admin/test_deployments_list.py
+++ b/apps/exams/tests/admin/test_deployments_list.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.constants import ErrorMessages
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+
+@override_settings(USE_EXAM_MOCK=False)
+class AdminExamDeploymentListAPITest(TestCase):
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="Python 시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.deployment = ExamDeployment.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE",
+            open_at=timezone.now() - timedelta(minutes=5),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(1990, 1, 1),
+            role=User.Role.ADMIN,
+            is_active=True,
+        )
+        self.staff_user = User.objects.create_user(
+            email="staff@example.com",
+            password="password123",
+            name="스태프",
+            nickname="스태프",
+            phone_number="01011112223",
+            gender=User.Gender.MALE,
+            birthday=date(1990, 1, 1),
+            role=User.Role.TA,
+            is_active=True,
+        )
+        self.student = User.objects.create_user(
+            email="student@example.com",
+            password="password123",
+            name="학생",
+            nickname="학생",
+            phone_number="01012345678",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.STUDENT,
+            is_active=True,
+        )
+        ExamSubmission.objects.create(
+            submitter=self.student,
+            deployment=self.deployment,
+            started_at=timezone.now() - timedelta(minutes=10),
+            cheating_count=0,
+            answers_json=[],
+            score=80,
+            correct_answer_count=8,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_list_deployments(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("results", data)
+        self.assertIn("count", data)
+        self.assertGreaterEqual(len(data["results"]), 1)
+
+    def test_staff_can_list_deployments(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            headers=self._auth_headers(self.staff_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.get("/api/v1/admin/exams/deployments/")
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.UNAUTHORIZED.value)
+
+    def test_returns_403_for_non_staff(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            headers=self._auth_headers(self.student),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.NO_DEPLOYMENT_LIST_PERMISSION.value)
+
+    def test_filter_by_search_keyword(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            {"search_keyword": "Python"},
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertGreaterEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["exam"]["title"], "Python 시험")
+
+    def test_filter_by_subject_id(self) -> None:
+        other_subject = Subject.objects.create(
+            course=self.course,
+            title="다른 과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject2.png",
+        )
+        other_exam = Exam.objects.create(subject=other_subject, title="다른 시험", thumbnail_img_url="exam2.png")
+        ExamDeployment.objects.create(
+            cohort=self.cohort,
+            exam=other_exam,
+            duration_time=30,
+            access_code="CODE2",
+            open_at=timezone.now() - timedelta(minutes=5),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            {"subject_id": self.subject.id},
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+
+    def test_filter_by_cohort_id(self) -> None:
+        other_cohort = Cohort.objects.create(
+            course=self.course,
+            number=2,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        ExamDeployment.objects.create(
+            cohort=other_cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE3",
+            open_at=timezone.now() - timedelta(minutes=5),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            {"cohort_id": self.cohort.id},
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+
+    def test_returns_400_for_invalid_sort(self) -> None:
+        response = self.client.get(
+            "/api/v1/admin/exams/deployments/",
+            {"sort": "invalid"},
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST.value)

--- a/apps/exams/urls/admin.py
+++ b/apps/exams/urls/admin.py
@@ -1,10 +1,10 @@
 from django.urls import path
 
-from apps.exams.views.admin.deployments_create import (
-    AdminExamDeploymentCreateAPIView,
-)
 from apps.exams.views.admin.deployments_detail import (
     AdminExamDeploymentDetailAPIView,
+)
+from apps.exams.views.admin.deployments_router import (
+    AdminExamDeploymentRouterAPIView,
 )
 from apps.exams.views.admin.deployments_status import (
     AdminExamDeploymentStatusAPIView,
@@ -25,7 +25,7 @@ urlpatterns = [
         AdminExamQuestionDeleteAPIView.as_view(),
         name="admin-exam-question-delete",
     ),
-    path("exams/deployments/", AdminExamDeploymentCreateAPIView.as_view(), name="admin-exam-deployment-create"),
+    path("exams/deployments/", AdminExamDeploymentRouterAPIView.as_view(), name="admin-exam-deployments"),
     path(
         "exams/deployments/<int:deployment_id>/",
         AdminExamDeploymentDetailAPIView.as_view(),

--- a/apps/exams/views/admin/deployments_detail.py
+++ b/apps/exams/views/admin/deployments_detail.py
@@ -25,6 +25,7 @@ from apps.exams.views.mixins import ExamsExceptionMixin
 
 @extend_schema(
     tags=["admin_exams"],
+    operation_id="admin_exam_deployments_detail",
     summary="어드민 배포 상세 조회",
     description="쪽지시험 배포 상세 정보를 조회합니다.",
     responses={

--- a/apps/exams/views/admin/deployments_list.py
+++ b/apps/exams/views/admin/deployments_list.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import NoReturn
+
+from django.conf import settings
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.utils.pagination import SimplePagePagination
+from apps.core.utils.permissions import IsStaffRole
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
+from apps.exams.serializers.admin.deployments_list import (
+    AdminExamDeploymentListItemSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin.deployments_list import (
+    AdminDeploymentListService,
+    InvalidAdminDeploymentListParams,
+)
+from apps.exams.views.mixins import ExamsExceptionMixin
+
+
+@extend_schema(
+    tags=["admin_exams"],
+    operation_id="admin_exam_deployments_list",
+    summary="어드민 배포 목록 조회",
+    description="쪽지시험 배포 내역을 페이지네이션/검색/필터/정렬로 조회합니다.",
+    parameters=[
+        OpenApiParameter(name="page", required=False, type=int, description="페이지(1부터)"),
+        OpenApiParameter(name="size", required=False, type=int, description="페이지 크기"),
+        OpenApiParameter(name="search_keyword", required=False, type=str, description="검색어(시험 제목)"),
+        OpenApiParameter(name="subject_id", required=False, type=int, description="과목 ID"),
+        OpenApiParameter(name="cohort_id", required=False, type=int, description="기수 ID"),
+        OpenApiParameter(
+            name="sort",
+            required=False,
+            type=str,
+            description="정렬 기준",
+            enum=["created_at", "submit_count", "avg_score"],
+        ),
+        OpenApiParameter(name="order", required=False, type=str, description="정렬 방향", enum=["asc", "desc"]),
+    ],
+    responses={
+        200: OpenApiResponse(description="OK"),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "유효하지 않은 조회 요청",
+                    value={"error_detail": ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST.value},
+                )
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[OpenApiExample("인증 실패", value={"error_detail": ErrorMessages.UNAUTHORIZED.value})],
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Forbidden",
+            examples=[
+                OpenApiExample(
+                    "권한 없음",
+                    value={"error_detail": ErrorMessages.NO_DEPLOYMENT_LIST_PERMISSION.value},
+                )
+            ],
+        ),
+    },
+)
+class AdminExamDeploymentListAPIView(ExamsExceptionMixin, APIView):
+    """어드민 쪽지시험 배포 목록 조회 API."""
+
+    permission_classes = [IsAuthenticated, IsStaffRole]
+    serializer_class = AdminExamDeploymentListItemSerializer
+    pagination_class = SimplePagePagination
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        if not request.user or not request.user.is_authenticated:
+            raise NotAuthenticated()
+        raise PermissionDenied(detail=ErrorMessages.NO_DEPLOYMENT_LIST_PERMISSION.value)
+
+    def get(self, request: Request) -> Response:
+        qp = request.query_params
+        if settings.USE_EXAM_MOCK:
+            payload = [
+                {
+                    "id": 77,
+                    "submit_count": 58,
+                    "avg_score": 72.3,
+                    "status": "Activated",
+                    "exam": {
+                        "id": 101,
+                        "title": "Python 기본 문법 테스트",
+                        "thumbnail_img_url": "https://img.com/images/sample.png",
+                    },
+                    "subject": {"id": 10, "name": "Python"},
+                    "cohort": {
+                        "id": 21,
+                        "number": 12,
+                        "display": "백엔드 12기",
+                        "course": {"id": 23, "name": "Backend Bootcamp", "tag": "BE"},
+                    },
+                    "created_at": "2025-03-01 14:20:33",
+                }
+            ]
+            paginator = self.pagination_class()
+            paginated_payload: list[dict[str, object]] | None = paginator.paginate_queryset(payload, request)  # type: ignore[arg-type]
+            return paginator.get_paginated_response(paginated_payload)
+
+        try:
+            params = AdminDeploymentListService.parse_params(
+                search_keyword=qp.get("search_keyword"),
+                subject_id=qp.get("subject_id"),
+                cohort_id=qp.get("cohort_id"),
+                sort=qp.get("sort"),
+                order=qp.get("order"),
+            )
+        except InvalidAdminDeploymentListParams as exc:
+            raise ErrorDetailException(str(exc), status.HTTP_400_BAD_REQUEST) from exc
+
+        queryset = AdminDeploymentListService.get_queryset(params)
+
+        paginator = self.pagination_class()
+        paginated_queryset = paginator.paginate_queryset(queryset, request)
+        serializer = self.serializer_class(paginated_queryset, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/apps/exams/views/admin/deployments_router.py
+++ b/apps/exams/views/admin/deployments_router.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Any
+
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.exams.constants import ErrorMessages
+from apps.exams.serializers.admin.deployments_create import (
+    AdminExamDeploymentCreateRequestSerializer,
+    AdminExamDeploymentCreateResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.views.admin.deployments_create import (
+    AdminExamDeploymentCreateAPIView,
+)
+from apps.exams.views.admin.deployments_list import (
+    AdminExamDeploymentListAPIView,
+)
+from apps.exams.views.mixins import ExamsExceptionMixin
+
+
+class AdminExamDeploymentRouterAPIView(ExamsExceptionMixin, APIView):
+    @extend_schema(
+        tags=["admin_exams"],
+        summary="어드민 배포 목록 조회",
+        description="쪽지시험 배포 내역을 페이지네이션/검색/필터/정렬로 조회합니다.",
+        parameters=[
+            OpenApiParameter(name="page", required=False, type=int, description="페이지(1부터)"),
+            OpenApiParameter(name="size", required=False, type=int, description="페이지 크기"),
+            OpenApiParameter(name="search_keyword", required=False, type=str, description="검색어(시험 제목)"),
+            OpenApiParameter(name="subject_id", required=False, type=int, description="과목 ID"),
+            OpenApiParameter(name="cohort_id", required=False, type=int, description="기수 ID"),
+            OpenApiParameter(
+                name="sort",
+                required=False,
+                type=str,
+                description="정렬 기준",
+                enum=["created_at", "submit_count", "avg_score"],
+            ),
+            OpenApiParameter(name="order", required=False, type=str, description="정렬 방향", enum=["asc", "desc"]),
+        ],
+        responses={
+            200: OpenApiResponse(description="OK"),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Bad Request",
+                examples=[
+                    OpenApiExample(
+                        "유효하지 않은 조회 요청",
+                        value={"error_detail": ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST.value},
+                    )
+                ],
+            ),
+            401: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Unauthorized",
+                examples=[OpenApiExample("인증 실패", value={"error_detail": ErrorMessages.UNAUTHORIZED.value})],
+            ),
+            403: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Forbidden",
+                examples=[
+                    OpenApiExample(
+                        "권한 없음",
+                        value={"error_detail": ErrorMessages.NO_DEPLOYMENT_LIST_PERMISSION.value},
+                    )
+                ],
+            ),
+        },
+    )
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return AdminExamDeploymentListAPIView.as_view()(request._request, *args, **kwargs)
+
+    @extend_schema(
+        tags=["admin_exams"],
+        summary="어드민 배포 생성",
+        description="쪽지시험 배포를 생성합니다.",
+        request=AdminExamDeploymentCreateRequestSerializer,
+        responses={
+            201: AdminExamDeploymentCreateResponseSerializer,
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Bad Request",
+                examples=[
+                    OpenApiExample(
+                        "유효하지 않은 배포 생성 요청",
+                        value={"error_detail": ErrorMessages.INVALID_DEPLOYMENT_CREATE_REQUEST.value},
+                    )
+                ],
+            ),
+            401: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Unauthorized",
+                examples=[
+                    OpenApiExample(
+                        "인증 실패",
+                        value={"error_detail": ErrorMessages.UNAUTHORIZED.value},
+                    )
+                ],
+            ),
+            403: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Forbidden",
+                examples=[
+                    OpenApiExample(
+                        "권한 없음",
+                        value={"error_detail": ErrorMessages.NO_DEPLOYMENT_CREATE_PERMISSION.value},
+                    )
+                ],
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Not Found",
+                examples=[
+                    OpenApiExample(
+                        "배포 대상 없음",
+                        value={"error_detail": ErrorMessages.DEPLOYMENT_TARGET_NOT_FOUND.value},
+                    )
+                ],
+            ),
+            409: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Conflict",
+                examples=[
+                    OpenApiExample(
+                        "중복 배포",
+                        value={"error_detail": ErrorMessages.DUPLICATE_DEPLOYMENT.value},
+                    )
+                ],
+            ),
+        },
+    )
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return AdminExamDeploymentCreateAPIView.as_view()(request._request, *args, **kwargs)

--- a/apps/exams/views/student/deployments_list.py
+++ b/apps/exams/views/student/deployments_list.py
@@ -97,6 +97,9 @@ class ExamListView(ExamsExceptionMixin, ListAPIView[ExamDeployment]):
     pagination_class = SimplePagePagination
 
     def get_queryset(self) -> QuerySet[ExamDeployment]:
+        if getattr(self, "swagger_fake_view", False):
+            return ExamDeployment.objects.none()
+
         user_id = self.request.user.id
         assert user_id is not None
         cohort_id = (


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 배포 목록 조회 API 추가 및 exams 스웨거 경고 정리

## 📄 상세 내용
- [x] 어드민 배포 목록 조회 API 추가
  - `apps/exams/views/admin/deployments_list.py` : `AdminExamDeploymentListAPIView.get` (목록 조회 + mock 분기)
  - `apps/exams/services/admin/deployments_list.py` : `AdminDeploymentListService.parse_params/get_queryset`
  - `apps/exams/serializers/admin/deployments_list.py` : 목록 응답 스키마(`AdminExamDeploymentListItemSerializer`)
  - `apps/exams/views/admin/deployments_router.py` : `AdminExamDeploymentRouterAPIView` (GET/POST 라우팅)
  - `apps/exams/urls/admin.py` : `/api/v1/admin/exams/deployments/` GET/POST 연결
- [x] 목록 조회 파라미터 검증/에러 메시지 보강
  - `apps/exams/constants.py` : `INVALID_DEPLOYMENT_LIST_REQUEST` 추가
  - `apps/exams/tests/admin/test_deployments_list.py` : 목록 조회 필터/권한/에러 테스트 추가
- [x] exams 스키마 경고 해소
  - `apps/exams/views/admin/deployments_list.py` : `operation_id="admin_exam_deployments_list"`
  - `apps/exams/views/admin/deployments_detail.py` : `operation_id="admin_exam_deployments_detail"`
  - `apps/exams/views/student/deployments_list.py` : `swagger_fake_view` 가드 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).