### PR TITLE
[refactor/qna/mock_and_parser] refactor: mock & parser 리팩터링

### DIFF
--- a/apps/qna/docs/api_response_examples.py
+++ b/apps/qna/docs/api_response_examples.py
@@ -26,7 +26,7 @@ class SuccessResponseExamples:
                     "category": {"id": 12, "depth": 2, "names": ["백엔드", "Django", "ORM"]},
                     "author": {
                         "id": 211,
-                        "nickname": "한율_회장",
+                        "nickname": "오즈 백엔드 15기 김동석",
                         "profile_image_url": "https://cdn.ozcodingschool.com/profiles/user_123.png",
                     },
                     "title": "Django ORM 역참조는 어떻게 사용하나요?",
@@ -81,20 +81,20 @@ class SuccessResponseExamples:
             "images": [{"id": 3, "img_url": "https://cdn.ozcodingschool.com/qna/img_20250301_101530.png"}],
             "view_count": 88,
             "created_at": "2025-03-01 10:25:33",
-            "author": {"id": 211, "nickname": "한솔_회장", "profile_image_url": None},
+            "author": {"id": 211, "nickname": "나일론동서크", "profile_image_url": None},
             "answers": [
                 {
                     "id": "31429",
                     "content": "답변 content",
                     "created_at": "2025-03-02 10:33:33",
                     "is_adopted": "FALSE",
-                    "author": {"id": "33", "nickname": "나일론동서크", "profile_image_url": None},
+                    "author": {"id": "33", "nickname": "소민 조교님", "profile_image_url": None},
                     "comments": [
                         {
                             "id": "14231",
                             "content": "댓글 content",
                             "created_at": "2025-03-05 10:33:33",
-                            "author": {"id": "324120", "nickname": "댓글 작성자 닉네임", "profile_image_url": None},
+                            "author": {"id": "324120", "nickname": "이준 조교님", "profile_image_url": None},
                         }
                     ],
                 }

--- a/apps/qna/docs/api_response_examples.py
+++ b/apps/qna/docs/api_response_examples.py
@@ -87,7 +87,7 @@ class SuccessResponseExamples:
                     "id": "31429",
                     "content": "답변 content",
                     "created_at": "2025-03-02 10:33:33",
-                    "is_adopted": "FALSE",
+                    "is_adopted": False,
                     "author": {"id": "33", "nickname": "소민 조교님", "profile_image_url": None},
                     "comments": [
                         {

--- a/apps/qna/mocks/mock_question.py
+++ b/apps/qna/mocks/mock_question.py
@@ -37,7 +37,7 @@ class QuestionMockService:
         for i in range(1, 11):
             # 템플릿을 복사하여 각 항목별로 고유한 값을 주입
             item = template_item.copy()
-            item["id"] = i + 1
+            item["id"] = i
             item["title"] = f"Mock 질문 제목 {i}"
             item["view_count"] = i * 15  # 조회수 가변 처리
 

--- a/apps/qna/mocks/mock_question.py
+++ b/apps/qna/mocks/mock_question.py
@@ -40,14 +40,12 @@ class QuestionMockService:
             item["id"] = i
             item["title"] = f"Mock 질문 제목 {i}"
             item["view_count"] = i * 15  # 조회수 가변 처리
-
+            item["content_preview"] = f"{i}번째 미리보기. " + item.get("content_preview", "")
             # 객체 변환
             obj = cast(SafeMockObject, cls._dict_to_obj(item))
             # 데이터 정제(Hydration) 수행
-            cls._hydrate_mock_object(obj)
-
+            cls._hydrate_mock_object(obj, is_list=True)
             mock_list.append(obj)
-
         return mock_list
 
     def get_mock_category_tree(cls) -> List[SafeMockObject]:
@@ -65,13 +63,12 @@ class QuestionMockService:
         raw_data["id"] = question_id
 
         obj = cast(SafeMockObject, cls._dict_to_obj(raw_data))
-        # 상세 조회 데이터도 목록과 동일한 로직으로 정제
         cls._hydrate_mock_object(obj)
 
         return obj
 
     @classmethod
-    def _hydrate_mock_object(cls, obj: SafeMockObject) -> None:
+    def _hydrate_mock_object(cls, obj: SafeMockObject, is_list: bool = False) -> None:
         """Serializer 인터페이스에 맞게 Mock 객체 데이터를 재구성"""
         # Serializer의 parent 순회 로직 대응
         if hasattr(obj, "category") and obj.category:
@@ -82,9 +79,20 @@ class QuestionMockService:
                     node_id = obj.category.id if i == len(names) - 1 else 0
                     current_node = SafeMockObject(id=node_id, name=name_str, parent=parent_node)
                     parent_node = current_node
-
+                obj.category = parent_node
                 # Serializer가 참조할 최종 계층 구조 객체로 교체
                 obj.category = parent_node
+
+        # Content & Thumbnail 처리
+        content = getattr(obj, "content", None)
+        # 목록 조회 시 content가 없고 content_preview만 있는 경우 대응
+        if is_list and not content:
+            content = getattr(obj, "content_preview", "Mock Content Body")
+            setattr(obj, "content", content)
+
+        if is_list:
+            setattr(obj, "content_preview", ContentParser.extract_content_preview(content, 50))
+            setattr(obj, "thumbnail_img_url", ContentParser.extract_thumbnail_img_url(content))
 
         #  ContentParser 대응
         current_content = getattr(obj, "content", None)
@@ -93,17 +101,14 @@ class QuestionMockService:
             preview_source = getattr(obj, "content_preview", "Mock Content Body")
             setattr(obj, "content", preview_source)
 
-        # Serializer의 ImageField 대응
+        # Author 이미지 및 필드 매핑
         if hasattr(obj, "author") and obj.author:
             author = obj.author
-            # JSON 예시의 문자열 URL을 DRF ImageField가 기대하는 .url 속성을 가진 객체로 변환
             img_url = getattr(author, "profile_image_url", None)
             if img_url and isinstance(img_url, str):
-                setattr(author, "profile_image_url", SafeMockObject(url=img_url))
-
-            # source="profile_image" 매핑 대응
-            if not getattr(author, "profile_image", None):
-                setattr(author, "profile_image", getattr(author, "profile_image_url", None))
+                wrapper = SafeMockObject(url=img_url)
+                setattr(author, "profile_img_url", wrapper)
+                setattr(author, "profile_image", wrapper)
 
     @staticmethod
     def _dict_to_obj(data: Any) -> Any:

--- a/apps/qna/mocks/mock_question.py
+++ b/apps/qna/mocks/mock_question.py
@@ -16,8 +16,40 @@ class SafeMockObject(SimpleNamespace):
 
 
 class QuestionMockService:
+    """
+    Mock 데이터 생성 서비스
+    """
 
     @classmethod
+    def get_mock_question_list(cls) -> List[SafeMockObject]:
+        """
+        예시 데이터의 'results' 리스트에 있는 첫 번째 항목을 템플릿으로 사용하여
+        10개의 Mock 질문 데이터를 생성
+        """
+        raw_results = SuccessResponseExamples.QUESTION_LIST.value.get("results", [])
+        if not raw_results:
+            return []
+
+        # 템플릿으로 사용할 첫 번째 데이터 확보
+        template_item = raw_results[0]
+        mock_list = []
+
+        for i in range(1, 11):
+            # 템플릿을 복사하여 각 항목별로 고유한 값을 주입
+            item = template_item.copy()
+            item["id"] = i + 1
+            item["title"] = f"Mock 질문 제목 {i}"
+            item["view_count"] = i * 15  # 조회수 가변 처리
+
+            # 객체 변환
+            obj = cast(SafeMockObject, cls._dict_to_obj(item))
+            # 데이터 정제(Hydration) 수행
+            cls._hydrate_mock_object(obj)
+
+            mock_list.append(obj)
+
+        return mock_list
+
     def get_mock_category_tree(cls) -> List[SafeMockObject]:
         """
         [신규] 카테고리 트리 전용 Mock 데이터 생성
@@ -26,6 +58,52 @@ class QuestionMockService:
         raw_categories = SuccessResponseExamples.QUESTION_CATEGORY_LIST.value.get("categories", [])
         # 리스트 내의 모든 dict를 재귀적으로 SafeMockObject로 변환
         return [cast(SafeMockObject, cls._dict_to_obj(cat)) for cat in raw_categories]
+
+    @classmethod
+    def get_mock_question_detail(cls, question_id: int) -> SafeMockObject:
+        raw_data = SuccessResponseExamples.QUESTION_DETAIL.value.copy()
+        raw_data["id"] = question_id
+
+        obj = cast(SafeMockObject, cls._dict_to_obj(raw_data))
+        # 상세 조회 데이터도 목록과 동일한 로직으로 정제
+        cls._hydrate_mock_object(obj)
+
+        return obj
+
+    @classmethod
+    def _hydrate_mock_object(cls, obj: SafeMockObject) -> None:
+        """Serializer 인터페이스에 맞게 Mock 객체 데이터를 재구성"""
+        # Serializer의 parent 순회 로직 대응
+        if hasattr(obj, "category") and obj.category:
+            names = getattr(obj.category, "names", [])
+            if names:
+                parent_node = None
+                for i, name_str in enumerate(names):
+                    node_id = obj.category.id if i == len(names) - 1 else 0
+                    current_node = SafeMockObject(id=node_id, name=name_str, parent=parent_node)
+                    parent_node = current_node
+
+                # Serializer가 참조할 최종 계층 구조 객체로 교체
+                obj.category = parent_node
+
+        #  ContentParser 대응
+        current_content = getattr(obj, "content", None)
+        if not current_content:
+            # content가 없다면 content_preview를 원본 데이터로 주입하여 Parser가 동작하게 함
+            preview_source = getattr(obj, "content_preview", "Mock Content Body")
+            setattr(obj, "content", preview_source)
+
+        # Serializer의 ImageField 대응
+        if hasattr(obj, "author") and obj.author:
+            author = obj.author
+            # JSON 예시의 문자열 URL을 DRF ImageField가 기대하는 .url 속성을 가진 객체로 변환
+            img_url = getattr(author, "profile_image_url", None)
+            if img_url and isinstance(img_url, str):
+                setattr(author, "profile_image_url", SafeMockObject(url=img_url))
+
+            # source="profile_image" 매핑 대응
+            if not getattr(author, "profile_image", None):
+                setattr(author, "profile_image", getattr(author, "profile_image_url", None))
 
     @staticmethod
     def _dict_to_obj(data: Any) -> Any:

--- a/apps/qna/models/question.py
+++ b/apps/qna/models/question.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from django.db import models
 
 from apps.core.models import TimeStampModel
 from apps.qna.models.question_category import QuestionCategory
+from apps.qna.utils.content_parser import ContentParser
 from apps.users.models import User
 
 
@@ -26,3 +29,14 @@ class Question(TimeStampModel):
 
     def __str__(self) -> str:
         return f"[{self.pk}] {self.title}"
+
+    @property
+    def content_preview(self) -> str:
+        """본문의 마크다운/HTML 태그를 제거한 미리보기 텍스트 반환"""
+        limit = 10
+        return ContentParser.extract_content_preview(self.content, limit) or ""
+
+    @property
+    def thumbnail_img_url(self) -> Optional[str]:
+        """본문 내 첫 번째 이미지 URL 반환"""
+        return ContentParser.extract_thumbnail_img_url(self.content)

--- a/apps/qna/serializers/question/response.py
+++ b/apps/qna/serializers/question/response.py
@@ -24,9 +24,10 @@ class QuestionListSerializer(serializers.ModelSerializer[Question]):
 
     category = QuestionCategoryListSerializer(read_only=True)
     author = QuestionAuthorSerializer(read_only=True)
-    content_preview = serializers.SerializerMethodField()
     answer_count = serializers.IntegerField(read_only=True)
-    thumbnail_img_url = serializers.SerializerMethodField()
+
+    content_preview = serializers.ReadOnlyField()
+    thumbnail_img_url = serializers.ReadOnlyField()
 
     class Meta:
         model = Question
@@ -41,14 +42,6 @@ class QuestionListSerializer(serializers.ModelSerializer[Question]):
             "created_at",
             "thumbnail_img_url",
         ]
-
-    def get_content_preview(self, obj: Question) -> str:
-        """본문 프리뷰 생성"""
-        return obj.content[:50] + "..." if len(obj.content) > 50 else obj.content
-
-    def get_thumbnail_img_url(self, obj: Question) -> Any:
-        """본문 내용에서 첫 번째 이미지 URL을 파싱하여 반환"""
-        return ContentParser.extract_thumbnail_img_url(obj.content)
 
 
 # ==============================================================================

--- a/apps/qna/utils/content_parser.py
+++ b/apps/qna/utils/content_parser.py
@@ -29,14 +29,11 @@ class ContentParser:
         return None
 
     @classmethod
-    def extract_preview_and_thumbnail(cls, content: Optional[str]) -> Tuple[str, Optional[str]]:
+    def extract_content_preview(cls, content: Optional[str], limit: int) -> Optional[str]:
         """목록 조회를 위해 이미지 태그 제거 텍스트, 썸네일 URL 반환"""
         # 입력값 검증
         if not content or not isinstance(content, str):
-            return "", None
-
-        # 2. 썸네일 추출
-        thumbnail = cls.extract_thumbnail_img_url(content)
+            return ""
 
         # 이미지 태그 제거 (마크다운 & HTML)
         clean_text = re.sub(r"!\[.*?\]\(.*?\)", "", content)
@@ -45,4 +42,10 @@ class ContentParser:
         # 불필요한 공백 및 줄바꿈 정리
         clean_text = re.sub(r"\s+", " ", clean_text).strip()
 
-        return clean_text, thumbnail
+        # 텍스트가 없을 경우 처리
+        if not clean_text:
+            clean_text = ""
+
+        preview = clean_text[:limit] + "..." if len(clean_text) > limit else clean_text
+
+        return preview

--- a/apps/qna/views/question_view.py
+++ b/apps/qna/views/question_view.py
@@ -133,7 +133,7 @@ class QuestionCreateListAPIView(QnaBaseAPIView):
         query_serializer = QuestionQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
 
-        queryset: Union[QuerySet[Question], list[SimpleNamespace]]
+        queryset: Union[QuerySet[Question], list[Any]]
         mock_param = str(request.query_params.get("mock", "")).lower()
         is_mock_requested = mock_param in ["true"]
         if settings.USE_QNA_MOCK or is_mock_requested:

--- a/apps/qna/views/question_view.py
+++ b/apps/qna/views/question_view.py
@@ -1,8 +1,8 @@
-from datetime import datetime
-from typing import Any, cast
+from types import SimpleNamespace
+from typing import Any, Union, cast
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
+from django.db.models import QuerySet
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -34,6 +34,7 @@ from apps.qna.serializers.question.response import (
 )
 from apps.qna.services.question.command import QuestionCommandService
 from apps.qna.services.question.query import QuestionQueryService
+from apps.qna.mocks import mock_question
 from apps.qna.utils.model_types import User
 from apps.qna.utils.permissions import IsStudent
 from apps.qna.utils.qna_paginator import QnAPaginator
@@ -132,33 +133,11 @@ class QuestionCreateListAPIView(QnaBaseAPIView):
         query_serializer = QuestionQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
 
-        # Mock Data 생성
-        if settings.USE_QNA_MOCK:
-            User = get_user_model()
-            mock_user = User(
-                id=1,
-                nickname="MockUser",
-                profile_img_url="https://ssl.pstatic.net/static/pwe/address/img_profile.png",
-            )
-
-            cat_root = QuestionCategory(id=1, name="개발")
-            cat_mid = QuestionCategory(id=2, name="백엔드", parent=cat_root)
-            cat_leaf = QuestionCategory(id=3, name="Django", parent=cat_mid)
-
-            queryset: Any = []
-            for i in range(1, 11):
-                q = Question(
-                    id=i,
-                    author=mock_user,
-                    category=cat_leaf,
-                    title=f"Mock 질문 제목 {i}",
-                    content=f"Mock 질문 내용입니다. {i} ![image](https://via.placeholder.com/150)",
-                    view_count=i * 10,
-                    created_at=datetime.now(),
-                )
-                # Annotate field manual injection
-                setattr(q, "answer_count", i % 3)
-                queryset.append(q)
+        queryset: Union[QuerySet[Question], list[SimpleNamespace]]
+        mock_param = str(request.query_params.get("mock", "")).lower()
+        is_mock_requested = mock_param in ["true"]
+        if settings.USE_QNA_MOCK or is_mock_requested:
+            queryset = mock_question.QuestionMockService.get_mock_question_list()
         else:
             queryset = QuestionQueryService.get_question_list(query_serializer.validated_data)
 
@@ -176,7 +155,7 @@ class QuestionDetailAPIView(QnaBaseAPIView):
     permission_classes = [AllowAny]
 
     # 질의응답 상세 조회
-    # GET /api/v1/qna/questions/{question_id}
+    # [GET] /api/v1/qna/questions/{question_id}
     @extend_schema(
         summary="질문 상세 조회 API",
         description=ApiDescriptions.QUESTION_DETAIL,
@@ -200,68 +179,14 @@ class QuestionDetailAPIView(QnaBaseAPIView):
         tags=["qna"],
     )
     def get(self, request: Request, question_id: int) -> Response:
-        # Mock Data 생성
-        if settings.USE_QNA_MOCK:
-            from types import SimpleNamespace
-
-            mock_user = SimpleNamespace(
-                id=1,
-                nickname="MockUser",
-                profile_img_url="https://ssl.pstatic.net/static/pwe/address/img_profile.png",
-            )
-
-            cat_root = SimpleNamespace(id=1, name="개발", parent=None)
-            cat_mid = SimpleNamespace(id=2, name="백엔드", parent=cat_root)
-            cat_leaf = SimpleNamespace(id=3, name="Django", parent=cat_mid)
-
-            question: Any = SimpleNamespace(
-                id=question_id,
-                author=mock_user,
-                category=cat_leaf,
-                title=f"Mock 상세 질문 제목 {question_id}",
-                content=f"Mock 상세 질문 내용입니다.\n\n![img](https://via.placeholder.com/200)",
-                view_count=123,
-                created_at=datetime.now(),
-            )
-
-            # Mock Images
-            question.images = [
-                SimpleNamespace(id=1, img_url="https://via.placeholder.com/200"),
-                SimpleNamespace(id=2, img_url="https://via.placeholder.com/201"),
-            ]
-
-            # Mock Comments for Answer
-            # AnswerComment also needs to be SimpleNamespace
-            comment1 = SimpleNamespace(
-                id=1,
-                author=mock_user,
-                content="Mock 댓글 1",
-                created_at=datetime.now(),
-            )
-            # Answer needs to link to comment
-            # Note: The AnswerSerializer typically expects 'comments' related name or field.
-            # In the model, it is related_name='comments'.
-            pass
-
-            # Mock Answers
-            ans1 = SimpleNamespace(
-                id=1,
-                question=question,
-                author=mock_user,
-                content="Mock 답변 내용 1",
-                created_at=datetime.now(),
-                is_adopted=False,
-                comments=[comment1],  # Directly assign list
-            )
-            # Fix comment reference back to answer if needed (usually circular not needed for serialization if one way)
-            comment1.answer = ans1
-
-            question.answers = [ans1]
-
+        question: Union[Question, SimpleNamespace]
+        is_mock_requested = request.query_params.get("mock") == "true"
+        if settings.USE_QNA_MOCK or is_mock_requested:
+            question = mock_question.QuestionMockService.get_mock_question_detail(question_id)
         else:
             question = QuestionQueryService.get_question_detail(question_id)
 
-        serializer = QuestionDetailSerializer(question)
+        serializer = QuestionDetailSerializer(cast(Any, question))
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 

--- a/apps/qna/views/question_view.py
+++ b/apps/qna/views/question_view.py
@@ -18,9 +18,9 @@ from apps.qna.docs.api_response_examples import (
     ErrorResponseExamples,
     SuccessResponseExamples,
 )
+from apps.qna.mocks import mock_question
 from apps.qna.models import (
     Question,
-    QuestionCategory,
 )
 from apps.qna.serializers.question.request import (
     QuestionCreateSerializer,
@@ -34,7 +34,6 @@ from apps.qna.serializers.question.response import (
 )
 from apps.qna.services.question.command import QuestionCommandService
 from apps.qna.services.question.query import QuestionQueryService
-from apps.qna.mocks import mock_question
 from apps.qna.utils.model_types import User
 from apps.qna.utils.permissions import IsStudent
 from apps.qna.utils.qna_paginator import QnAPaginator
@@ -209,7 +208,7 @@ class QuestionCategoryTreeAPIView(QnaBaseAPIView):
                 examples=[SuccessResponseExamples.QUESTION_CATEGORY_LIST],
             ),
             400: OpenApiResponse(
-                description="Bad Request", examples=[ErrorResponseExamples.QUESTION_CATEGORY_LIST_400]
+                description="Bad Request", response=dict, examples=[ErrorResponseExamples.QUESTION_CATEGORY_LIST_400]
             ),
         },
         tags=["qna"],


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: mock & parser 리팩터링

## 📄 상세 내용
- [x] mock을 views에서 분리하여 mock/로 리팩터링
- [x] parser 리팩터링
    - 시리얼라이저에 있던 파싱을 모델의 Property 데코레이터와 파싱 유틸리티에서 처리하도록 리팩터링

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
