### PR TITLE
[refactor/exams-api-cleanup] ♻️ refactor: 학생 시험 목록 조회 서비스 분리 및 권한 강화

### DIFF
--- a/apps/exams/services/student/deployments_list.py
+++ b/apps/exams/services/student/deployments_list.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.db import models
+from django.db.models import (
+    BooleanField,
+    Case,
+    CharField,
+    Count,
+    IntegerField,
+    OuterRef,
+    QuerySet,
+    Subquery,
+    Sum,
+    Value,
+    When,
+)
+from django.db.models.functions import Coalesce
+from rest_framework import status
+
+from apps.courses.models import CohortStudent
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
+from apps.exams.models.exam_deployments import ExamDeployment
+from apps.exams.models.exam_submissions import ExamSubmission
+from apps.exams.serializers.student.deployments_list import ExamListQuerySerializer
+
+
+@dataclass(frozen=True)
+class ExamListParams:
+    user_id: int
+    status: str
+
+
+class ExamDeploymentListService:
+    @staticmethod
+    def _get_cohort_id(user_id: int) -> int:
+        cohort_id = (
+            CohortStudent.objects.filter(user_id=user_id)
+            .order_by("created_at")
+            .values_list("cohort_id", flat=True)
+            .first()
+        )
+        if cohort_id is None:
+            raise ErrorDetailException(ErrorMessages.USER_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
+        return int(cohort_id)
+
+    @staticmethod
+    def _parse_status(params: dict[str, str]) -> str:
+        query_serializer = ExamListQuerySerializer(data=params)
+        if not query_serializer.is_valid():
+            raise ErrorDetailException(ErrorMessages.INVALID_EXAM_LIST_REQUEST.value, status.HTTP_404_NOT_FOUND)
+        return str(query_serializer.validated_data["status"])
+
+    @classmethod
+    def build_queryset(cls, params: ExamListParams) -> QuerySet[ExamDeployment]:
+        latest_sub = ExamSubmission.objects.filter(
+            submitter_id=params.user_id,
+            deployment_id=OuterRef("pk"),
+        ).order_by("-created_at")
+
+        submission_id_sq = Subquery(latest_sub.values("id")[:1])
+        score_sq = Subquery(latest_sub.values("score")[:1])
+        correct_sq = Subquery(latest_sub.values("correct_answer_count")[:1])
+        answers_json_sq = Subquery(latest_sub.values("answers_json")[:1])
+        empty_json = Value({}, output_field=models.JSONField())
+
+        qs = (
+            ExamDeployment.objects.filter(cohort_id=cls._get_cohort_id(params.user_id))
+            .select_related("exam__subject")
+            .annotate(
+                question_count=Count("exam__questions", distinct=True),
+                total_score=Coalesce(
+                    Sum("exam__questions__point", distinct=True),
+                    Value(0),
+                    output_field=IntegerField(),
+                ),
+                submission_id=submission_id_sq,
+                score=Coalesce(score_sq, Value(0), output_field=IntegerField()),
+                correct_answer_count=Coalesce(correct_sq, Value(0), output_field=IntegerField()),
+                answers_json=answers_json_sq,
+            )
+            .annotate(
+                exam_status=Case(
+                    When(submission_id__isnull=True, then=Value("pending")),
+                    When(answers_json=empty_json, then=Value("pending")),
+                    default=Value("done"),
+                    output_field=CharField(),
+                ),
+                is_done=Case(
+                    When(submission_id__isnull=True, then=Value(False)),
+                    When(answers_json=empty_json, then=Value(False)),
+                    default=Value(True),
+                    output_field=BooleanField(),
+                ),
+            )
+            .order_by("-created_at")
+        )
+
+        if params.status == "done":
+            qs = qs.filter(exam_status="done")
+        elif params.status == "pending":
+            qs = qs.filter(exam_status="pending")
+
+        return qs
+
+    @classmethod
+    def from_request(cls, *, user_id: int, query_params: dict[str, str]) -> QuerySet[ExamDeployment]:
+        status_value = cls._parse_status(query_params)
+        return cls.build_queryset(ExamListParams(user_id=user_id, status=status_value))

--- a/apps/exams/tests/student/test_deployments_list.py
+++ b/apps/exams/tests/student/test_deployments_list.py
@@ -8,6 +8,7 @@ from apps.courses.models.cohort_students import CohortStudent
 from apps.courses.models.cohorts import Cohort
 from apps.courses.models.courses import Course
 from apps.courses.models.subjects import Subject
+from apps.exams.constants import ErrorMessages
 from apps.exams.models import Exam, ExamDeployment
 from apps.users.models import User
 
@@ -46,6 +47,17 @@ class ExamDeploymentListAPITest(TestCase):
             role=User.Role.STUDENT,
             is_active=True,
         )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="일반유저",
+            nickname="유저",
+            phone_number="01098765432",
+            gender=User.Gender.MALE,
+            birthday=date(1999, 1, 1),
+            role=User.Role.USER,
+            is_active=True,
+        )
 
         CohortStudent.objects.create(user=self.student, cohort=self.cohort)
 
@@ -73,3 +85,9 @@ class ExamDeploymentListAPITest(TestCase):
     def test_list_requires_authentication(self) -> None:
         res = self.client.get(self.url)
         self.assertIn(res.status_code, [401, 403])
+
+    def test_list_returns_403_for_non_student(self) -> None:
+        res = self.client.get(self.url, HTTP_AUTHORIZATION=self._bearer(self.normal_user))
+        self.assertEqual(res.status_code, 403)
+        data = res.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.FORBIDDEN.value)

--- a/apps/exams/views/student/deployments_list.py
+++ b/apps/exams/views/student/deployments_list.py
@@ -1,41 +1,24 @@
 from __future__ import annotations
 
-from django.db import models
-from django.db.models import (
-    BooleanField,
-    Case,
-    CharField,
-    Count,
-    IntegerField,
-    OuterRef,
-    QuerySet,
-    Subquery,
-    Sum,
-    Value,
-    When,
-)
-from django.db.models.functions import Coalesce
+from django.db.models import QuerySet
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
     OpenApiResponse,
     extend_schema,
 )
-from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 
 from apps.core.utils.pagination import SimplePagePagination
-from apps.courses.models import CohortStudent
+from apps.core.utils.permissions import IsStudentRole
 from apps.exams.constants import ErrorMessages
-from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models.exam_deployments import ExamDeployment
-from apps.exams.models.exam_submissions import ExamSubmission
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.serializers.student.deployments_list import (
     ExamDeploymentListSerializer,
-    ExamListQuerySerializer,
 )
+from apps.exams.services.student.deployments_list import ExamDeploymentListService
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -92,7 +75,7 @@ from apps.exams.views.mixins import ExamsExceptionMixin
     },
 )
 class ExamListView(ExamsExceptionMixin, ListAPIView[ExamDeployment]):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsStudentRole]
     serializer_class = ExamDeploymentListSerializer
     pagination_class = SimplePagePagination
 
@@ -102,66 +85,5 @@ class ExamListView(ExamsExceptionMixin, ListAPIView[ExamDeployment]):
 
         user_id = self.request.user.id
         assert user_id is not None
-        cohort_id = (
-            CohortStudent.objects.filter(user_id=user_id)
-            .order_by("created_at")
-            .values_list("cohort_id", flat=True)
-            .first()
-        )
-
-        if cohort_id is None:
-            raise ErrorDetailException(ErrorMessages.USER_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
-
-        query_serializer = ExamListQuerySerializer(data=self.request.query_params)
-        if not query_serializer.is_valid():
-            raise ErrorDetailException(ErrorMessages.INVALID_EXAM_LIST_REQUEST.value, status.HTTP_404_NOT_FOUND)
-        status_param = query_serializer.validated_data["status"]
-
-        latest_sub = ExamSubmission.objects.filter(submitter_id=user_id, deployment_id=OuterRef("pk")).order_by(
-            "-created_at"
-        )
-
-        submission_id_sq = Subquery(latest_sub.values("id")[:1])
-        score_sq = Subquery(latest_sub.values("score")[:1])
-        correct_sq = Subquery(latest_sub.values("correct_answer_count")[:1])
-        answers_json_sq = Subquery(latest_sub.values("answers_json")[:1])
-        empty_json = Value({}, output_field=models.JSONField())
-
-        qs = (
-            ExamDeployment.objects.filter(cohort_id=cohort_id)
-            .select_related("exam__subject")
-            .annotate(
-                question_count=Count("exam__questions", distinct=True),
-                total_score=Coalesce(
-                    Sum("exam__questions__point", distinct=True),
-                    Value(0),
-                    output_field=IntegerField(),
-                ),
-                submission_id=submission_id_sq,
-                score=Coalesce(score_sq, Value(0), output_field=IntegerField()),
-                correct_answer_count=Coalesce(correct_sq, Value(0), output_field=IntegerField()),
-                answers_json=answers_json_sq,
-            )
-            .annotate(
-                exam_status=Case(
-                    When(submission_id__isnull=True, then=Value("pending")),
-                    When(answers_json=empty_json, then=Value("pending")),
-                    default=Value("done"),
-                    output_field=CharField(),
-                ),
-                is_done=Case(
-                    When(submission_id__isnull=True, then=Value(False)),
-                    When(answers_json=empty_json, then=Value(False)),
-                    default=Value(True),
-                    output_field=BooleanField(),
-                ),
-            )
-            .order_by("-created_at")
-        )
-
-        if status_param == "done":
-            qs = qs.filter(exam_status="done")
-        elif status_param == "pending":
-            qs = qs.filter(exam_status="pending")
-
-        return qs
+        query_params = self.request.query_params.dict()
+        return ExamDeploymentListService.from_request(user_id=user_id, query_params=query_params)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 학생 시험 목록 조회 로직 서비스 분리 및 권한 강화

## 📄 상세 내용
- [x] 학생 목록 조회 로직 서비스 분리
  - `apps/exams/services/student/deployments_list.py` : `ExamDeploymentListService`
  - `apps/exams/views/student/deployments_list.py` : `ExamListView.get_queryset`
- [x] 학생 목록 조회 권한 강화
  - `apps/exams/views/student/deployments_list.py` : `IsStudentRole` 추가
- [x] 권한 테스트 보강
  - `apps/exams/tests/student/test_deployments_list.py` : 비학생 접근 403 테스트 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- `ExamListQuerySerializer` 검증 실패 시 기존과 동일하게 404 반환

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).