### PR TITLE
[feature/admin-submission-delete] 응시내역 삭제 API 구현

### DIFF
--- a/apps/exams/constants.py
+++ b/apps/exams/constants.py
@@ -67,6 +67,7 @@ class ErrorMessages(str, Enum):
     DEPLOYMENT_DELETE_NOT_FOUND = "삭제할 배포 정보를 찾을 수 없습니다."
     SUBMISSION_LIST_NOT_FOUND = "조회된 응시 내역이 없습니다."
     SUBMISSION_DETAIL_NOT_FOUND = "해당 응시 내역을 찾을 수 없습니다."
+    SUBMISSION_DELETE_NOT_FOUND = "삭제할 응시 내역을 찾을 수 없습니다."
     USER_NOT_FOUND = "사용자 정보를 찾을 수 없습니다."
 
     # 409

--- a/apps/exams/serializers/admin/submissions_delete.py
+++ b/apps/exams/serializers/admin/submissions_delete.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamSubmissionDeleteResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 응시 내역 삭제 응답 스키마."""
+
+    submission_id = serializers.IntegerField()

--- a/apps/exams/services/admin/submissions_delete.py
+++ b/apps/exams/services/admin/submissions_delete.py
@@ -1,0 +1,25 @@
+from django.db import transaction
+
+from apps.exams.models import ExamSubmission
+
+
+class ExamSubmissionDeleteNotFoundError(Exception):
+    """삭제할 응시 내역을 찾지 못했을 때 발생."""
+
+
+class ExamSubmissionDeleteConflictError(Exception):
+    """응시 내역 삭제 중 충돌 발생 시."""
+
+
+def delete_exam_submission(submission_id: int) -> dict[str, int]:
+    submission = ExamSubmission.objects.filter(id=submission_id).first()
+    if not submission:
+        raise ExamSubmissionDeleteNotFoundError
+
+    try:
+        with transaction.atomic():
+            submission.delete()
+    except Exception as exc:
+        raise ExamSubmissionDeleteConflictError from exc
+
+    return {"submission_id": submission_id}

--- a/apps/exams/tests/admin/test_submissions_delete.py
+++ b/apps/exams/tests/admin/test_submissions_delete.py
@@ -93,7 +93,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
     def test_admin_can_delete_submission(self) -> None:
         response = self.client.delete(
-            f"/api/v1/admin/submissions/{self.submission.id}/",
+            f"/api/v1/admin/exams/submissions/{self.submission.id}/",
             headers=self._auth_headers(self.admin_user),
         )
 
@@ -104,7 +104,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
     def test_returns_401_when_unauthenticated(self) -> None:
         response = self.client.delete(
-            f"/api/v1/admin/submissions/{self.submission.id}/",
+            f"/api/v1/admin/exams/submissions/{self.submission.id}/",
         )
 
         self.assertEqual(response.status_code, 401)
@@ -113,7 +113,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
     def test_returns_403_for_non_staff(self) -> None:
         response = self.client.delete(
-            f"/api/v1/admin/submissions/{self.submission.id}/",
+            f"/api/v1/admin/exams/submissions/{self.submission.id}/",
             headers=self._auth_headers(self.normal_user),
         )
 
@@ -123,7 +123,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
     def test_returns_404_when_submission_missing(self) -> None:
         response = self.client.delete(
-            "/api/v1/admin/submissions/9999/",
+            "/api/v1/admin/exams/submissions/9999/",
             headers=self._auth_headers(self.admin_user),
         )
 
@@ -133,7 +133,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
     def test_returns_400_when_invalid_ids(self) -> None:
         response = self.client.delete(
-            "/api/v1/admin/submissions/0/",
+            "/api/v1/admin/exams/submissions/0/",
             headers=self._auth_headers(self.admin_user),
         )
 

--- a/apps/exams/tests/admin/test_submissions_delete.py
+++ b/apps/exams/tests/admin/test_submissions_delete.py
@@ -119,9 +119,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         data = response.json()
-        self.assertEqual(
-            data["error_detail"], ErrorMessages.NO_SUBMISSION_DELETE_PERMISSION.value
-        )
+        self.assertEqual(data["error_detail"], ErrorMessages.NO_SUBMISSION_DELETE_PERMISSION.value)
 
     def test_returns_404_when_submission_missing(self) -> None:
         response = self.client.delete(
@@ -131,9 +129,7 @@ class AdminExamSubmissionDeleteAPITest(TestCase):
 
         self.assertEqual(response.status_code, 404)
         data = response.json()
-        self.assertEqual(
-            data["error_detail"], ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value
-        )
+        self.assertEqual(data["error_detail"], ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value)
 
     def test_returns_400_when_invalid_ids(self) -> None:
         response = self.client.delete(

--- a/apps/exams/tests/admin/test_submissions_delete.py
+++ b/apps/exams/tests/admin/test_submissions_delete.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from typing import Any
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.constants import ErrorMessages
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.users.models import User
+
+
+class AdminExamSubmissionDeleteAPITest(TestCase):
+    """어드민 응시내역 삭제 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.deployment = ExamDeployment.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=30,
+            access_code="CODE",
+            open_at=timezone.now() - timedelta(minutes=5),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+            is_active=True,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.STUDENT,
+            is_active=True,
+        )
+        self.submission = ExamSubmission.objects.create(
+            submitter=self.normal_user,
+            deployment=self.deployment,
+            started_at=timezone.now() - timedelta(minutes=20),
+            cheating_count=0,
+            answers_json=json.dumps([]),
+            score=80,
+            correct_answer_count=8,
+        )
+
+    def _auth_headers(self, user: User) -> Any:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_delete_submission(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/submissions/{self.submission.id}/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["submission_id"], self.submission.id)
+        self.assertFalse(ExamSubmission.objects.filter(id=self.submission.id).exists())
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/submissions/{self.submission.id}/",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.UNAUTHORIZED.value)
+
+    def test_returns_403_for_non_staff(self) -> None:
+        response = self.client.delete(
+            f"/api/v1/admin/submissions/{self.submission.id}/",
+            headers=self._auth_headers(self.normal_user),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(
+            data["error_detail"], ErrorMessages.NO_SUBMISSION_DELETE_PERMISSION.value
+        )
+
+    def test_returns_404_when_submission_missing(self) -> None:
+        response = self.client.delete(
+            "/api/v1/admin/submissions/9999/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(
+            data["error_detail"], ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value
+        )
+
+    def test_returns_400_when_invalid_ids(self) -> None:
+        response = self.client.delete(
+            "/api/v1/admin/submissions/0/",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(
+            data["error_detail"],
+            ErrorMessages.INVALID_SUBMISSION_DELETE_REQUEST.value,
+        )

--- a/apps/exams/urls/admin.py
+++ b/apps/exams/urls/admin.py
@@ -13,6 +13,7 @@ from apps.exams.views.admin.exams_detail import AdminExamDetailAPIView
 from apps.exams.views.admin.exams_router import AdminExamRouterAPIView
 from apps.exams.views.admin.questions_create import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin.questions_delete import AdminExamQuestionDeleteAPIView
+from apps.exams.views.admin.submissions_delete import AdminExamSubmissionDeleteAPIView
 from apps.exams.views.admin.submissions_list import AdminExamSubmissionListAPIView
 
 urlpatterns = [
@@ -36,5 +37,10 @@ urlpatterns = [
         "exams/deployments/<int:deployment_id>/status/",
         AdminExamDeploymentStatusAPIView.as_view(),
         name="admin-exam-deployment-status",
+    ),
+    path(
+        "exams/submissions/<int:submission_id>/",
+        AdminExamSubmissionDeleteAPIView.as_view(),
+        name="admin-exam-submission-delete",
     ),
 ]

--- a/apps/exams/views/admin/submissions_delete.py
+++ b/apps/exams/views/admin/submissions_delete.py
@@ -1,0 +1,116 @@
+from typing import NoReturn
+
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.utils.permissions import IsStaffRole
+from apps.exams.constants import ErrorMessages
+from apps.exams.serializers.admin.submissions_delete import (
+    AdminExamSubmissionDeleteResponseSerializer,
+)
+from apps.exams.serializers.error_serializers import ErrorResponseSerializer
+from apps.exams.services.admin.submissions_delete import (
+    ExamSubmissionDeleteConflictError,
+    ExamSubmissionDeleteNotFoundError,
+    delete_exam_submission,
+)
+from apps.exams.views.mixins import ExamsExceptionMixin
+
+
+@extend_schema(
+    tags=["admin_exams"],
+    summary="어드민 응시 내역 삭제",
+    description="쪽지시험 응시 내역을 삭제합니다.",
+    responses={
+        200: AdminExamSubmissionDeleteResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "유효하지 않은 응시 내역 삭제 요청",
+                    value={"error_detail": ErrorMessages.INVALID_SUBMISSION_DELETE_REQUEST.value},
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 실패",
+                    value={"error_detail": ErrorMessages.UNAUTHORIZED.value},
+                ),
+            ],
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Forbidden",
+            examples=[
+                OpenApiExample(
+                    "권한 없음",
+                    value={"error_detail": ErrorMessages.NO_SUBMISSION_DELETE_PERMISSION.value},
+                ),
+            ],
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Not Found",
+            examples=[
+                OpenApiExample(
+                    "응시 내역 없음",
+                    value={"error_detail": ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value},
+                ),
+            ],
+        ),
+        409: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Conflict",
+            examples=[
+                OpenApiExample(
+                    "응시 내역 삭제 충돌",
+                    value={"error_detail": ErrorMessages.SUBMISSION_DELETE_CONFLICT.value},
+                ),
+            ],
+        ),
+    },
+)
+class AdminExamSubmissionDeleteAPIView(ExamsExceptionMixin, APIView):
+    """어드민 쪽지시험 응시 내역 삭제 API."""
+
+    permission_classes = [IsAuthenticated, IsStaffRole]
+    serializer_class = AdminExamSubmissionDeleteResponseSerializer
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        if not request.user or not request.user.is_authenticated:
+            raise NotAuthenticated()
+        raise PermissionDenied(detail=ErrorMessages.NO_SUBMISSION_DELETE_PERMISSION.value)
+
+    def delete(self, request: Request, submission_id: int) -> Response:
+        if submission_id <= 0:
+            return Response(
+                {"error_detail": ErrorMessages.INVALID_SUBMISSION_DELETE_REQUEST.value},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            result = delete_exam_submission(submission_id)
+        except ExamSubmissionDeleteNotFoundError:
+            return Response(
+                {"error_detail": ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ExamSubmissionDeleteConflictError:
+            return Response(
+                {"error_detail": ErrorMessages.SUBMISSION_DELETE_CONFLICT.value},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        serializer = self.serializer_class(data=result)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: REQ-TEST-021
- 작업 요약: 응시내역 삭제 API 구현

## 📄 상세 내용
- [x] constants.py에 404 응답용 에러 메시지 상수 추가
- [x] services/admin/submissions_delete.py에 비즈니스 로직 구현
- [x] views/admin/submissions_delete.py에 DELETE용 APIView 구현
- [x] questions_delete(문제 삭제)를 참고해, 서비스·시리얼라이저·뷰 구조를 동일하게 맞춤

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
