### PR TITLE
[feature/admin-withdrawal-reason-counts] 어드민 전체 기간 회원 탈퇴 사유별 집계 API 구현

### DIFF
--- a/apps/users/admin_urls.py
+++ b/apps/users/admin_urls.py
@@ -77,7 +77,7 @@ urlpatterns = [
     # Analytics
     path("analytics/signup/trends", AdminSignupTrendsAPIView.as_view(), name="admin-signup-trends"),
     path(
-        "analytics/withdrawals/trends/",
+        "analytics/withdrawals/trends",
         AdminWithdrawalTrendsAPIView.as_view(),
         name="admin-withdrawal-trends",
     ),
@@ -87,7 +87,7 @@ urlpatterns = [
         name="admin-student-enrollment-trends",
     ),
     path(
-        "analytics/withdrawals/reasons/counts/",
+        "analytics/withdrawal-reasons/counts",
         AdminWithdrawalReasonCountsAPIView.as_view(),
         name="admin-withdrawal-reason-counts",
     ),

--- a/apps/users/admin_urls.py
+++ b/apps/users/admin_urls.py
@@ -11,6 +11,7 @@ from apps.users.views.admin.admin_account_role_views import (
 from apps.users.views.admin.admin_account_views import AdminAccountUpdateAPIView
 from apps.users.views.admin.admin_analytics_views import (
     AdminSignupTrendsAPIView,
+    AdminWithdrawalReasonCountsAPIView,
     AdminStudentEnrollmentTrendsAPIView,
     AdminWithdrawalTrendsAPIView,
 )
@@ -84,5 +85,10 @@ urlpatterns = [
         "analytics/student-enrollments/trends/",
         AdminStudentEnrollmentTrendsAPIView.as_view(),
         name="admin-student-enrollment-trends",
+    ),
+    path(
+        "analytics/withdrawals/reasons/counts/",
+        AdminWithdrawalReasonCountsAPIView.as_view(),
+        name="admin-withdrawal-reason-counts",
     ),
 ]

--- a/apps/users/admin_urls.py
+++ b/apps/users/admin_urls.py
@@ -11,8 +11,8 @@ from apps.users.views.admin.admin_account_role_views import (
 from apps.users.views.admin.admin_account_views import AdminAccountUpdateAPIView
 from apps.users.views.admin.admin_analytics_views import (
     AdminSignupTrendsAPIView,
-    AdminWithdrawalReasonCountsAPIView,
     AdminStudentEnrollmentTrendsAPIView,
+    AdminWithdrawalReasonCountsAPIView,
     AdminWithdrawalTrendsAPIView,
 )
 from apps.users.views.admin.admin_student_enrollment_views import (

--- a/apps/users/serializers/admin/admin_analytics_serializers.py
+++ b/apps/users/serializers/admin/admin_analytics_serializers.py
@@ -1,6 +1,8 @@
-from typing import Any
+from typing import Any, cast
 
 from rest_framework import serializers
+
+from apps.users.models import Withdrawal
 
 
 # 회원가입 추세 분석 요청
@@ -66,3 +68,17 @@ class StudentEnrollmentTrendsResponseSerializer(serializers.Serializer[Any]):
     to_date = serializers.DateField()
     total = serializers.IntegerField()
     items = TrendsItemSerializer(many=True)
+
+
+class AdminWithdrawalReasonCountItemSerializer(serializers.Serializer[Any]):
+    reason = serializers.ChoiceField(choices=cast(Any, Withdrawal.Reason.choices))
+    reason_label = serializers.CharField()
+    count = serializers.IntegerField()
+    percentage = serializers.FloatField()
+
+
+class AdminWithdrawalReasonCountsResponseSerializer(serializers.Serializer[Any]):
+    from_date = serializers.DateField(allow_null=True)
+    to_date = serializers.DateField(allow_null=True)
+    total = serializers.IntegerField()
+    items = AdminWithdrawalReasonCountItemSerializer(many=True)

--- a/apps/users/services/admin_analytics_service.py
+++ b/apps/users/services/admin_analytics_service.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Any, TypedDict
 
-from django.db.models import Count, Min
+from django.db.models import Count, Max, Min
 from django.db.models.functions import TruncMonth, TruncYear
 
 from apps.courses.models.cohort_students import CohortStudent
@@ -243,6 +243,29 @@ def get_student_enrollment_trends(interval: str, year: int | None = None) -> dic
 
     return {
         "interval": interval,
+        "from_date": from_date,
+        "to_date": to_date,
+        "total": total,
+        "items": items,
+    }
+
+
+def get_withdrawal_reason_counts() -> dict[str, Any]:
+    total = Withdrawal.objects.count()
+    qs = Withdrawal.objects.values("reason").annotate(count=Count("id"))
+    items = [
+        {
+            "reason": row["reason"],
+            "reason_label": Withdrawal.Reason(row["reason"]).label,
+            "count": row["count"],
+        }
+        for row in qs
+    ]
+    oldest = Withdrawal.objects.aggregate(oldest=Min("created_at"))["oldest"]
+    from_date = oldest.date() if oldest else None
+    latest = Withdrawal.objects.aggregate(latest=Max("created_at"))["latest"]
+    to_date = latest.date() if latest else None
+    return {
         "from_date": from_date,
         "to_date": to_date,
         "total": total,

--- a/apps/users/services/admin_analytics_service.py
+++ b/apps/users/services/admin_analytics_service.py
@@ -253,11 +253,13 @@ def get_student_enrollment_trends(interval: str, year: int | None = None) -> dic
 def get_withdrawal_reason_counts() -> dict[str, Any]:
     total = Withdrawal.objects.count()
     qs = Withdrawal.objects.values("reason").annotate(count=Count("id"))
+
     items = [
         {
             "reason": row["reason"],
             "reason_label": Withdrawal.Reason(row["reason"]).label,
             "count": row["count"],
+            "percentage": round((row["count"] / total) * 100, 2) if total else 0.0,
         }
         for row in qs
     ]

--- a/apps/users/tests/test_admin_withdrawal_reason_counts.py
+++ b/apps/users/tests/test_admin_withdrawal_reason_counts.py
@@ -199,3 +199,28 @@ class AdminWithdrawalReasonCountsAPITest(TestCase):
         data = response.json()
         self.assertEqual(data["from_date"], f"{self.prev_year}-12-10")
         self.assertEqual(data["to_date"], f"{self.current_year}-01-10")
+
+    def test_withdrawal_percentage_is_100_when_single_item(self) -> None:
+        w_user = User.objects.create_user(
+            email="wd_percentage_1@example.com",
+            password="password123",
+            name="탈퇴퍼센트1",
+            nickname="탈퇴퍼센트1",
+            phone_number="01040000001",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 2, 2),
+            role=User.Role.USER,
+            is_active=False,
+        )
+        Withdrawal.objects.create(
+            user=w_user,
+            reason=Withdrawal.Reason.OTHER,
+            reason_detail="test",
+        )
+
+        response = self.client.get(self.url, **self._auth_headers(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["items"][0]["percentage"], 100.0)

--- a/apps/users/tests/test_admin_withdrawal_reason_counts.py
+++ b/apps/users/tests/test_admin_withdrawal_reason_counts.py
@@ -1,0 +1,201 @@
+from datetime import date, datetime
+from typing import Any
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.users.models import User, Withdrawal
+
+
+class AdminWithdrawalReasonCountsAPITest(TestCase):
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/admin/analytics/withdrawals/reasons/counts/"
+
+        self.admin_user = User.objects.create_user(
+            email="admin_wd@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011111111",
+            gender=User.Gender.MALE,
+            birthday=date(1990, 1, 1),
+            role=User.Role.ADMIN,
+            is_active=True,
+        )
+
+        self.normal_user = User.objects.create_user(
+            email="normal_wd@example.com",
+            password="password123",
+            name="일반유저",
+            nickname="일반유저",
+            phone_number="01077777777",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 5, 5),
+            role=User.Role.USER,
+            is_active=True,
+        )
+
+    def _auth_headers(self, user: User) -> Any:
+        token = AccessToken.for_user(user)
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_unauthenticated_request_returns_401(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_general_user_request_returns_403(self) -> None:
+        response = self.client.get(self.url, **self._auth_headers(self.normal_user))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.json().get("error_detail"), "권한이 없습니다.")
+
+    def test_admin_user_request_returns_200(self) -> None:
+        response = self.client.get(self.url, **self._auth_headers(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_withdrawal_total_count(self) -> None:
+        w_user = User.objects.create_user(
+            email="wd_data_1@example.com",
+            password="password123",
+            name="탈퇴1",
+            nickname="탈퇴1",
+            phone_number="01030000001",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 1, 1),
+            role=User.Role.USER,
+            is_active=False,
+        )
+        Withdrawal.objects.create(
+            user=w_user,
+            reason=Withdrawal.Reason.OTHER,
+            reason_detail="test",
+        )
+
+        response = self.client.get(self.url, **self._auth_headers(self.admin_user))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 1)
+
+    def test_withdrawal_item_reason(self) -> None:
+
+        w_user2 = User.objects.create_user(
+            email="wd_data_2@example.com",
+            password="password123",
+            name="탈퇴2",
+            nickname="탈퇴2",
+            phone_number="01030000002",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 1, 2),
+            role=User.Role.USER,
+            is_active=False,
+        )
+        w_user3 = User.objects.create_user(
+            email="wd_data_3@example.com",
+            password="password123",
+            name="탈퇴3",
+            nickname="탈퇴3",
+            phone_number="01030000003",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 1, 3),
+            role=User.Role.USER,
+            is_active=False,
+        )
+        self.w2 = Withdrawal.objects.create(
+            user=w_user2,
+            reason=Withdrawal.Reason.PRIVACY_CONCERN,
+            reason_detail="test",
+        )
+        self.w3 = Withdrawal.objects.create(
+            user=w_user3,
+            reason=Withdrawal.Reason.SERVICE_DISSATISFACTION,
+            reason_detail="test",
+        )
+        response = self.client.get(self.url, **self._auth_headers(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        items = response.json()["items"]
+        reason_counts = {item["reason"]: item["count"] for item in items}
+
+        self.assertEqual(reason_counts[Withdrawal.Reason.PRIVACY_CONCERN.value], 1)  # type: ignore[misc]
+        self.assertEqual(reason_counts[Withdrawal.Reason.SERVICE_DISSATISFACTION.value], 1)  # type: ignore[misc]
+
+    def test_withdrawal_reason_label(self) -> None:
+
+        w_user = User.objects.create_user(
+            email="wd_data_1@example.com",
+            password="password123",
+            name="탈퇴1",
+            nickname="탈퇴1",
+            phone_number="01030000001",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 1, 1),
+            role=User.Role.USER,
+            is_active=False,
+        )
+        Withdrawal.objects.create(
+            user=w_user,
+            reason=Withdrawal.Reason.OTHER,
+            reason_detail="test",
+        )
+
+        response = self.client.get(self.url, **self._auth_headers(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        items = response.json()["items"]
+        self.assertIn("reason_label", items[0])
+
+    def test_withdrawal_date(self) -> None:
+        today = date.today()
+        self.current_year = today.year
+        self.prev_year = today.year - 1
+
+        w_user2 = User.objects.create_user(
+            email="wd_data_2@example.com",
+            password="password123",
+            name="탈퇴2",
+            nickname="탈퇴2",
+            phone_number="01030000002",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 1, 2),
+            role=User.Role.USER,
+            is_active=False,
+        )
+        w_user3 = User.objects.create_user(
+            email="wd_data_3@example.com",
+            password="password123",
+            name="탈퇴3",
+            nickname="탈퇴3",
+            phone_number="01030000003",
+            gender=User.Gender.MALE,
+            birthday=date(1998, 1, 3),
+            role=User.Role.USER,
+            is_active=False,
+        )
+
+        self.w2 = Withdrawal.objects.create(
+            user=w_user2,
+            reason=Withdrawal.Reason.PRIVACY_CONCERN,
+            reason_detail="test",
+        )
+        self.w3 = Withdrawal.objects.create(
+            user=w_user3,
+            reason=Withdrawal.Reason.SERVICE_DISSATISFACTION,
+            reason_detail="test",
+        )
+
+        Withdrawal.objects.filter(id=self.w2.id).update(
+            created_at=timezone.make_aware(datetime(self.prev_year, 12, 10, 10, 0, 0))
+        )
+        Withdrawal.objects.filter(id=self.w3.id).update(
+            created_at=timezone.make_aware(datetime(self.current_year, 1, 10, 10, 0, 0))
+        )
+
+        response = self.client.get(self.url, **self._auth_headers(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(data["from_date"], f"{self.prev_year}-12-10")
+        self.assertEqual(data["to_date"], f"{self.current_year}-01-10")

--- a/apps/users/tests/test_admin_withdrawal_reason_counts.py
+++ b/apps/users/tests/test_admin_withdrawal_reason_counts.py
@@ -14,7 +14,7 @@ class AdminWithdrawalReasonCountsAPITest(TestCase):
 
     def setUp(self) -> None:
         self.client = APIClient()
-        self.url = "/api/v1/admin/analytics/withdrawals/reasons/counts/"
+        self.url = "/api/v1/admin/analytics/withdrawal-reasons/counts"
 
         self.admin_user = User.objects.create_user(
             email="admin_wd@example.com",

--- a/apps/users/tests/test_admin_withdrawal_trends.py
+++ b/apps/users/tests/test_admin_withdrawal_trends.py
@@ -15,7 +15,7 @@ class AdminWithdrawalTrendsAPITest(TestCase):
 
     def setUp(self) -> None:
         self.client = APIClient()
-        self.url = "/api/v1/admin/analytics/withdrawals/trends/"
+        self.url = "/api/v1/admin/analytics/withdrawals/trends"
 
         # 관리자 유저
         self.admin_user = User.objects.create_user(

--- a/apps/users/views/admin/admin_analytics_views.py
+++ b/apps/users/views/admin/admin_analytics_views.py
@@ -19,8 +19,8 @@ from apps.users.serializers.admin.admin_analytics_serializers import (
 )
 from apps.users.services.admin_analytics_service import (
     get_signup_trends,
-    get_withdrawal_reason_counts,
     get_student_enrollment_trends,
+    get_withdrawal_reason_counts,
     get_withdrawal_trends,
 )
 

--- a/apps/users/views/admin/admin_analytics_views.py
+++ b/apps/users/views/admin/admin_analytics_views.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 
 from apps.users.permissions import IsAdminStaff
 from apps.users.serializers.admin.admin_analytics_serializers import (
+    AdminWithdrawalReasonCountsResponseSerializer,
     SignupTrendsRequestSerializer,
     SignupTrendsResponseSerializer,
     StudentEnrollmentTrendsRequestSerializer,
@@ -257,14 +258,9 @@ class AdminWithdrawalReasonCountsAPIView(APIView):
     @extend_schema(
         tags=["admin_accounts"],
         summary="어드민 페이지 전체 기간 회원 탈퇴 사유별 갯수 API",
-        responses={
-            200: OpenApiResponse(
-                description="성공",
-            ),
-            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
-            403: OpenApiResponse(description="권한이 없습니다."),
-        },
+        responses={200: AdminWithdrawalReasonCountsResponseSerializer},
     )
     def get(self, request: Request) -> Response:
         result = get_withdrawal_reason_counts()
-        return Response(result, status=200)
+        serializer = AdminWithdrawalReasonCountsResponseSerializer(result)
+        return Response(serializer.data, status=200)

--- a/apps/users/views/admin/admin_analytics_views.py
+++ b/apps/users/views/admin/admin_analytics_views.py
@@ -18,6 +18,7 @@ from apps.users.serializers.admin.admin_analytics_serializers import (
 )
 from apps.users.services.admin_analytics_service import (
     get_signup_trends,
+    get_withdrawal_reason_counts,
     get_student_enrollment_trends,
     get_withdrawal_trends,
 )
@@ -223,3 +224,47 @@ class AdminStudentEnrollmentTrendsAPIView(APIView):
 
         response_serializer = StudentEnrollmentTrendsResponseSerializer(result)
         return Response(response_serializer.data, status=200)
+
+
+class AdminWithdrawalReasonCountsAPIView(APIView):
+    permission_classes = [IsAuthenticated, IsAdminStaff]
+
+    def handle_exception(self, exc: Exception) -> Response:
+        response = super().handle_exception(exc)
+
+        if isinstance(exc, (NotAuthenticated, PermissionDenied)) and response is not None:
+            detail = response.data.get("detail")
+
+            if isinstance(detail, dict) and "error_detail" in detail:
+                message = detail["error_detail"]
+            else:
+                default_msg = (
+                    "자격 인증 데이터가 제공되지 않았습니다."
+                    if isinstance(exc, NotAuthenticated)
+                    else "권한이 없습니다."
+                )
+                message = detail if isinstance(detail, str) else default_msg
+
+            response.data = {"error_detail": message}
+
+        return response
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        if not request.user or not request.user.is_authenticated:
+            raise NotAuthenticated(detail="자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied(detail="권한이 없습니다.")
+
+    @extend_schema(
+        tags=["admin_accounts"],
+        summary="어드민 페이지 전체 기간 회원 탈퇴 사유별 갯수 API",
+        responses={
+            200: OpenApiResponse(
+                description="성공",
+            ),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="권한이 없습니다."),
+        },
+    )
+    def get(self, request: Request) -> Response:
+        result = get_withdrawal_reason_counts()
+        return Response(result, status=200)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어드민 페이지 전체 기간 기준 회원 탈퇴 사유별 집계 데이터를 조회 API 구현

## 📄 상세 내용
- [ v ] 어드민 전체 기간 회원 탈퇴 사유별 갯수 조회 API 구현
- [ v ] API 동작 및 응답 구조에 대한 테스트 코드 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ v ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ v ] 변경 사항에 대한 테스트를 했습니다. (API 테스트 및 스웨거 동작 확인)
