### PR TITLE
[feature/admin deployment update] 어드민 배포수정 API 구현 

### DIFF
--- a/apps/exams/serializers/admin/deployments_update.py
+++ b/apps/exams/serializers/admin/deployments_update.py
@@ -11,10 +11,15 @@ class AdminExamDeploymentUpdateRequestSerializer(serializers.Serializer[Any]):
     duration_time = serializers.IntegerField(min_value=1, required=True)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        if attrs["open_at"] >= attrs["close_at"]:
-            from apps.exams.constants import ErrorMessages
+        from apps.exams.constants import ErrorMessages
 
+        if attrs["open_at"] >= attrs["close_at"]:
             raise serializers.ValidationError(ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value)
+
+        window_minutes = (attrs["close_at"] - attrs["open_at"]).total_seconds() / 60
+        if attrs["duration_time"] > window_minutes:
+            raise serializers.ValidationError(ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value)
+
         return attrs
 
 

--- a/apps/exams/serializers/admin/deployments_update.py
+++ b/apps/exams/serializers/admin/deployments_update.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminExamDeploymentUpdateRequestSerializer(serializers.Serializer[Any]):
+    """쪽지시험 배포 수정 요청 스키마."""
+
+    open_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S", required=True)
+    close_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S", required=True)
+    duration_time = serializers.IntegerField(min_value=1, required=True)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs["open_at"] >= attrs["close_at"]:
+            from apps.exams.constants import ErrorMessages
+
+            raise serializers.ValidationError(ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value)
+        return attrs
+
+
+class AdminExamDeploymentUpdateResponseSerializer(serializers.Serializer[Any]):
+    """쪽지시험 배포 수정 응답 스키마."""
+
+    deployment_id = serializers.IntegerField()
+    duration_time = serializers.IntegerField()
+    open_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    close_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")

--- a/apps/exams/services/admin/deployments_update.py
+++ b/apps/exams/services/admin/deployments_update.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from apps.exams.models import ExamDeployment
 
 
@@ -5,7 +7,7 @@ class ExamDeploymentUpdateNotFoundError(Exception):
     """수정할 배포 정보를 찾지 못했을 때 발생."""
 
 
-def update_exam_deployment(deployment_id: int, validated_data: dict) -> ExamDeployment:
+def update_exam_deployment(deployment_id: int, validated_data: dict[str, Any]) -> ExamDeployment:
     try:
         deployment = ExamDeployment.objects.get(id=deployment_id)
     except ExamDeployment.DoesNotExist as exc:

--- a/apps/exams/services/admin/deployments_update.py
+++ b/apps/exams/services/admin/deployments_update.py
@@ -1,0 +1,19 @@
+from apps.exams.models import ExamDeployment
+
+
+class ExamDeploymentUpdateNotFoundError(Exception):
+    """수정할 배포 정보를 찾지 못했을 때 발생."""
+
+
+def update_exam_deployment(deployment_id: int, validated_data: dict) -> ExamDeployment:
+    try:
+        deployment = ExamDeployment.objects.get(id=deployment_id)
+    except ExamDeployment.DoesNotExist as exc:
+        raise ExamDeploymentUpdateNotFoundError from exc
+
+    deployment.open_at = validated_data["open_at"]
+    deployment.close_at = validated_data["close_at"]
+    deployment.duration_time = validated_data["duration_time"]
+    deployment.save(update_fields=["open_at", "close_at", "duration_time", "updated_at"])
+
+    return deployment

--- a/apps/exams/tests/admin/test_deployments_update.py
+++ b/apps/exams/tests/admin/test_deployments_update.py
@@ -1,0 +1,165 @@
+from datetime import date, datetime, timedelta
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.constants import ErrorMessages
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion
+from apps.users.models import User
+
+
+@override_settings(USE_EXAM_MOCK=False)
+class AdminExamDeploymentUpdateAPITest(TestCase):
+    """어드민 쪽지시험 배포 수정 API 테스트."""
+
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=11,
+            max_student=30,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.question = ExamQuestion.objects.create(
+            exam=self.exam,
+            question="OX 문제",
+            type=ExamQuestion.TypeChoices.OX,
+            answer="O",
+            point=5,
+            explanation="",
+        )
+        self.deployment = ExamDeployment.objects.create(
+            exam=self.exam,
+            cohort=self.cohort,
+            duration_time=45,
+            access_code="ACCESSCODE",
+            open_at=timezone.make_aware(datetime(2025, 3, 2, 10, 0, 0)),
+            close_at=timezone.make_aware(datetime(2025, 3, 2, 12, 0, 0)),
+            questions_snapshot_json=[
+                {
+                    "question_id": self.question.id,
+                    "type": self.question.type,
+                    "question": self.question.question,
+                    "prompt": self.question.prompt,
+                    "blank_count": self.question.blank_count,
+                    "options": None,
+                    "point": self.question.point,
+                }
+            ],
+        )
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011112222",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.ADMIN,
+            is_active=True,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="사용자",
+            phone_number="01011113333",
+            gender=User.Gender.FEMALE,
+            birthday=date(2000, 1, 2),
+            role=User.Role.USER,
+            is_active=True,
+        )
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_admin_can_update_deployment(self) -> None:
+        payload = {
+            "open_at": "2025-03-02 10:30:00",
+            "close_at": "2025-03-02 12:30:00",
+            "duration_time": 50,
+        }
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
+            data=payload,
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": self._auth_headers(self.admin_user)["Authorization"]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["deployment_id"], self.deployment.id)
+        self.assertEqual(data["duration_time"], 50)
+        self.assertEqual(data["open_at"], "2025-03-02 10:30:00")
+        self.assertEqual(data["close_at"], "2025-03-02 12:30:00")
+        self.assertIn("updated_at", data)
+
+    def test_returns_400_when_invalid_deployment_id(self) -> None:
+        response = self.client.patch(
+            "/api/v1/admin/exams/deployments/0/",
+            data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": self._auth_headers(self.admin_user)["Authorization"]},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value)
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
+            data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.UNAUTHORIZED.value)
+
+    def test_returns_403_for_non_staff(self) -> None:
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
+            data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": self._auth_headers(self.normal_user)["Authorization"]},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.NO_DEPLOYMENT_UPDATE_PERMISSION.value)
+
+    def test_returns_404_when_deployment_missing(self) -> None:
+        response = self.client.patch(
+            "/api/v1/admin/exams/deployments/9999/",
+            data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": self._auth_headers(self.admin_user)["Authorization"]},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.DEPLOYMENT_UPDATE_NOT_FOUND.value)

--- a/apps/exams/tests/admin/test_deployments_update.py
+++ b/apps/exams/tests/admin/test_deployments_update.py
@@ -106,7 +106,7 @@ class AdminExamDeploymentUpdateAPITest(TestCase):
             f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
             data=payload,
             content_type="application/json",
-            **{"HTTP_AUTHORIZATION": self._auth_headers(self.admin_user)["Authorization"]},
+            headers=self._auth_headers(self.admin_user),
         )
 
         self.assertEqual(response.status_code, 200)
@@ -122,7 +122,7 @@ class AdminExamDeploymentUpdateAPITest(TestCase):
             "/api/v1/admin/exams/deployments/0/",
             data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
             content_type="application/json",
-            **{"HTTP_AUTHORIZATION": self._auth_headers(self.admin_user)["Authorization"]},
+            headers=self._auth_headers(self.admin_user),
         )
 
         self.assertEqual(response.status_code, 400)
@@ -145,7 +145,7 @@ class AdminExamDeploymentUpdateAPITest(TestCase):
             f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
             data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
             content_type="application/json",
-            **{"HTTP_AUTHORIZATION": self._auth_headers(self.normal_user)["Authorization"]},
+            headers=self._auth_headers(self.normal_user),
         )
 
         self.assertEqual(response.status_code, 403)
@@ -157,7 +157,7 @@ class AdminExamDeploymentUpdateAPITest(TestCase):
             "/api/v1/admin/exams/deployments/9999/",
             data={"open_at": "2025-03-02 10:00:00", "close_at": "2025-03-02 12:00:00", "duration_time": 45},
             content_type="application/json",
-            **{"HTTP_AUTHORIZATION": self._auth_headers(self.admin_user)["Authorization"]},
+            headers=self._auth_headers(self.admin_user),
         )
 
         self.assertEqual(response.status_code, 404)

--- a/apps/exams/tests/admin/test_deployments_update.py
+++ b/apps/exams/tests/admin/test_deployments_update.py
@@ -117,6 +117,34 @@ class AdminExamDeploymentUpdateAPITest(TestCase):
         self.assertEqual(data["close_at"], "2025-03-02 12:30:00")
         self.assertIn("updated_at", data)
 
+        self.deployment.refresh_from_db()
+        self.assertEqual(self.deployment.duration_time, 50)
+        self.assertEqual(
+            self.deployment.open_at,
+            timezone.make_aware(datetime(2025, 3, 2, 10, 30, 0)),
+        )
+        self.assertEqual(
+            self.deployment.close_at,
+            timezone.make_aware(datetime(2025, 3, 2, 12, 30, 0)),
+        )
+
+    def test_returns_400_when_duration_exceeds_window(self) -> None:
+        """시험 시간이 배포 구간(open_at~close_at)보다 길면 400."""
+        payload = {
+            "open_at": "2025-03-02 10:00:00",
+            "close_at": "2025-03-02 11:00:00",  # 1시간 = 60분
+            "duration_time": 90,  # 90분 > 60분
+        }
+        response = self.client.patch(
+            f"/api/v1/admin/exams/deployments/{self.deployment.id}/",
+            data=payload,
+            content_type="application/json",
+            headers=self._auth_headers(self.admin_user),
+        )
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["error_detail"], ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value)
+
     def test_returns_400_when_invalid_deployment_id(self) -> None:
         response = self.client.patch(
             "/api/v1/admin/exams/deployments/0/",

--- a/apps/exams/views/admin/deployments_detail.py
+++ b/apps/exams/views/admin/deployments_detail.py
@@ -14,10 +14,18 @@ from apps.exams.constants import ErrorMessages
 from apps.exams.serializers.admin.deployments_detail import (
     AdminExamDeploymentDetailResponseSerializer,
 )
+from apps.exams.serializers.admin.deployments_update import (
+    AdminExamDeploymentUpdateRequestSerializer,
+    AdminExamDeploymentUpdateResponseSerializer,
+)
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.services.admin.deployments_detail import (
     ExamDeploymentDetailNotFoundError,
     get_exam_deployment_detail,
+)
+from apps.exams.services.admin.deployments_update import (
+    ExamDeploymentUpdateNotFoundError,
+    update_exam_deployment,
 )
 from apps.exams.views.mixins import ExamsExceptionMixin
 
@@ -80,7 +88,12 @@ class AdminExamDeploymentDetailAPIView(ExamsExceptionMixin, APIView):
     def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
         if not request.user or not request.user.is_authenticated:
             raise NotAuthenticated()
-        raise PermissionDenied(detail=ErrorMessages.NO_DEPLOYMENT_DETAIL_PERMISSION.value)
+        detail_message = (
+            ErrorMessages.NO_DEPLOYMENT_UPDATE_PERMISSION.value
+            if request.method == "PATCH"
+            else ErrorMessages.NO_DEPLOYMENT_DETAIL_PERMISSION.value
+        )
+        raise PermissionDenied(detail=detail_message)
 
     def get(self, request: Request, deployment_id: int) -> Response:
         if deployment_id <= 0:
@@ -102,3 +115,87 @@ class AdminExamDeploymentDetailAPIView(ExamsExceptionMixin, APIView):
 
         serializer = self.serializer_class(payload)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        tags=["admin_exams"],
+        operation_id="admin_exam_deployment_update",
+        summary="어드민 배포 수정",
+        description="쪽지시험 배포 정보(시작/종료 일시, 시험 시간)를 수정합니다.",
+        request=AdminExamDeploymentUpdateRequestSerializer,
+        responses={
+            200: AdminExamDeploymentUpdateResponseSerializer,
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Bad Request",
+                examples=[
+                    OpenApiExample(
+                        "유효하지 않은 배포 수정 요청",
+                        value={"error_detail": ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value},
+                    ),
+                ],
+            ),
+            401: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Unauthorized",
+                examples=[
+                    OpenApiExample(
+                        "인증 실패",
+                        value={"error_detail": ErrorMessages.UNAUTHORIZED.value},
+                    ),
+                ],
+            ),
+            403: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Forbidden",
+                examples=[
+                    OpenApiExample(
+                        "권한 없음",
+                        value={"error_detail": ErrorMessages.NO_DEPLOYMENT_UPDATE_PERMISSION.value},
+                    ),
+                ],
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Not Found",
+                examples=[
+                    OpenApiExample(
+                        "배포 정보 없음",
+                        value={"error_detail": ErrorMessages.DEPLOYMENT_UPDATE_NOT_FOUND.value},
+                    ),
+                ],
+            ),
+        },
+    )
+    def patch(self, request: Request, deployment_id: int) -> Response:
+        """배포 정보 수정 (open_at, close_at, duration_time)."""
+        if deployment_id <= 0:
+            return Response(
+                {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = AdminExamDeploymentUpdateRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_UPDATE_REQUEST.value},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            deployment = update_exam_deployment(deployment_id, serializer.validated_data)
+        except ExamDeploymentUpdateNotFoundError:
+            return Response(
+                {"error_detail": ErrorMessages.DEPLOYMENT_UPDATE_NOT_FOUND.value},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        response_serializer = AdminExamDeploymentUpdateResponseSerializer(
+            {
+                "deployment_id": deployment.id,
+                "duration_time": deployment.duration_time,
+                "open_at": deployment.open_at,
+                "close_at": deployment.close_at,
+                "updated_at": deployment.updated_at,
+            }
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: REQ-TEST-018
- 작업 요약: 어드민 쪽지시험 배포 수정 API(PATCH) 구현 (배포 상세 조회와 동일 URL에 PATCH를 추가해 open_at, close_at, duration_time 수정 가능하도록 했다.)

## 📄 상세 내용
- [x]  배포 수정 요청/응답 시리얼라이저 추가 (serializers/admin/deployments_update.py)
- [x]  배포 수정 서비스 로직 추가 (services/admin/deployments_update.py) — update_exam_deployment
- [x]  AdminExamDeploymentDetailAPIView에 patch 메서드 추가 및 PATCH 시 권한 거부 메시지 분기
- [x] 배포 수정 API 테스트 추가 (tests/admin/test_deployments_update.py)
- [x]  Swagger 문서용 @extend_schema 추가 (어드민 배포 수정)

## 📸 스크린샷 (선택)
<img width="714" height="729" alt="배포수정 API 스웨거 검증" src="https://github.com/user-attachments/assets/b4ab47a1-bd27-4675-9fae-501255ce8685" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
