### PR TITLE
[refactor/exams-swagger-router-docs] admin_exams 스웨거/요청 스펙 정리

### DIFF
--- a/apps/exams/serializers/admin/exams_create.py
+++ b/apps/exams/serializers/admin/exams_create.py
@@ -19,7 +19,7 @@ class AdminExamCreateRequestSerializer(serializers.Serializer[Any]):
     )
 
     def validate_thumbnail_img(self, value: Any) -> Any:
-        if value is None:
+        if value in (None, ""):
             return value
         content_type = getattr(value, "content_type", None)
         if content_type not in {"image/jpeg", "image/png", "image/jpg"}:

--- a/apps/exams/views/admin/exams_create.py
+++ b/apps/exams/views/admin/exams_create.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import NoReturn
 
-from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
-from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,7 +16,6 @@ from apps.exams.serializers.admin.exams_create import (
     AdminExamCreateRequestSerializer,
     AdminExamCreateResponseSerializer,
 )
-from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.services.admin.exams_create import (
     ExamCreateConflictError,
     ExamCreateNotFoundError,
@@ -26,70 +24,11 @@ from apps.exams.services.admin.exams_create import (
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
-@extend_schema(
-    tags=["admin_exams"],
-    summary="어드민 시험 생성",
-    description="관리자/스태프 권한으로 쪽지시험을 생성합니다. 썸네일 이미지는 선택 입력입니다.",
-    request=AdminExamCreateRequestSerializer,
-    responses={
-        201: AdminExamCreateResponseSerializer,
-        400: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Bad Request",
-            examples=[
-                OpenApiExample(
-                    "유효하지 않은 시험 생성 요청",
-                    value={"error_detail": ErrorMessages.INVALID_EXAM_CREATE_REQUEST.value},
-                )
-            ],
-        ),
-        401: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Unauthorized",
-            examples=[
-                OpenApiExample(
-                    "인증 실패",
-                    value={"error_detail": ErrorMessages.UNAUTHORIZED.value},
-                )
-            ],
-        ),
-        403: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Forbidden",
-            examples=[
-                OpenApiExample(
-                    "권한 없음",
-                    value={"error_detail": ErrorMessages.NO_EXAM_CREATE_PERMISSION.value},
-                )
-            ],
-        ),
-        404: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Not Found",
-            examples=[
-                OpenApiExample(
-                    "과목 정보 없음",
-                    value={"error_detail": ErrorMessages.SUBJECT_NOT_FOUND.value},
-                )
-            ],
-        ),
-        409: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Conflict",
-            examples=[
-                OpenApiExample(
-                    "시험 이름 중복",
-                    value={"error_detail": ErrorMessages.EXAM_CONFLICT.value},
-                )
-            ],
-        ),
-    },
-)
 class AdminExamCreateAPIView(ExamsExceptionMixin, APIView):
     """관리자 쪽지시험 생성 API."""
 
     permission_classes = [IsAuthenticated, IsStaffRole]
-    parser_classes = [MultiPartParser, FormParser]
+    parser_classes = [MultiPartParser, FormParser, JSONParser]
     serializer_class = AdminExamCreateRequestSerializer
 
     def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:

--- a/apps/exams/views/admin/exams_list.py
+++ b/apps/exams/views/admin/exams_list.py
@@ -1,12 +1,6 @@
 from typing import NoReturn
 
 from django.db.models import QuerySet
-from drf_spectacular.utils import (
-    OpenApiExample,
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-)
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -18,7 +12,6 @@ from apps.exams.constants import ErrorMessages
 from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import Exam
 from apps.exams.serializers.admin.exams_list import AdminExamListItemSerializer
-from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.services.admin.exams_list import (
     AdminExamListService,
     InvalidAdminExamListParams,
@@ -26,41 +19,6 @@ from apps.exams.services.admin.exams_list import (
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
-@extend_schema(
-    tags=["admin_exams"],
-    summary="어드민 시험 목록 조회",
-    description="어드민 시험 목록을 페이지네이션/검색/과목필터/정렬로 조회합니다.",
-    parameters=[
-        OpenApiParameter(name="page", required=False, type=int, description="페이지(1부터)"),
-        OpenApiParameter(name="size", required=False, type=int, description="페이지 크기"),
-        OpenApiParameter(name="search_keyword", required=False, type=str, description="검색어(시험 제목)"),
-        OpenApiParameter(name="subject_id", required=False, type=int, description="과목 ID"),
-        OpenApiParameter(name="sort", required=False, type=str, description="정렬 기준", enum=["created_at", "title"]),
-        OpenApiParameter(name="order", required=False, type=str, description="정렬 방향", enum=["asc", "desc"]),
-    ],
-    responses={
-        200: OpenApiResponse(description="OK"),
-        400: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Bad Request",
-            examples=[
-                OpenApiExample(
-                    "유효하지 않은 조회 요청", value={"error_detail": ErrorMessages.INVALID_EXAM_LIST_REQUEST.value}
-                )
-            ],
-        ),
-        401: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Unauthorized",
-            examples=[OpenApiExample("인증 실패", value={"error_detail": ErrorMessages.UNAUTHORIZED.value})],
-        ),
-        403: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="Forbidden",
-            examples=[OpenApiExample("권한 없음", value={"error_detail": ErrorMessages.NO_EXAM_LIST_PERMISSION.value})],
-        ),
-    },
-)
 class AdminExamListView(ExamsExceptionMixin, ListAPIView[Exam]):
     permission_classes = [IsAuthenticated, IsStaffRole]
     serializer_class = AdminExamListItemSerializer

--- a/apps/exams/views/admin/exams_router.py
+++ b/apps/exams/views/admin/exams_router.py
@@ -86,10 +86,8 @@ class AdminExamRouterAPIView(ExamsExceptionMixin, APIView):
 
     @extend_schema(
         tags=["admin_exams"],
-        summary="관리자 쪽지시험 생성 API",
-        description="""
-            관리자/스태프 권한으로 쪽지시험을 생성합니다.
-            """,
+        summary="어드민 시험 생성",
+        description="관리자/스태프 권한으로 쪽지시험을 생성합니다. 썸네일 이미지는 선택 입력입니다.",
         request=AdminExamCreateRequestSerializer,
         responses={
             201: AdminExamCreateResponseSerializer,


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 시험 생성 스펙(JSON 허용) 및 스웨거 문구 통일

## 📄 상세 내용
- [x] 시험 생성 API JSON 요청 허용
  - `apps/exams/views/admin/exams_create.py` : JSONParser 추가
  - `apps/exams/serializers/admin/exams_create.py` : thumbnail_img 선택 입력 및 빈값 처리
- [x] 스웨거 문구 라우터 기준으로 통일
  - `apps/exams/views/admin/exams_router.py` : summary/description 정리
  - `apps/exams/views/admin/exams_list.py` / `apps/exams/views/admin/exams_create.py` : 중복 extend_schema 제거

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 썸네일 미첨부 JSON 요청도 생성 가능

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
