### PR TITLE
[refactor/qna/fe_request/get-question_list] refactor: 프론트 요청-필터링 결과에 따라 [] or 404 값 반환 리팩터링

### DIFF
--- a/apps/qna/services/question/query.py
+++ b/apps/qna/services/question/query.py
@@ -29,35 +29,62 @@ class QuestionQueryService:
         - Raises:
             QnaBaseException: 조건에 맞는 질문이 하나도 없을 경우 (404)
         """
-        queryset = Question.objects.select_related("author", "category__parent__parent").annotate(
-            answer_count=Count("answers")
-        )
 
-        search_keyword = filters.get("search_keyword")
-        if search_keyword:
-            queryset = queryset.filter(Q(title__icontains=search_keyword) | Q(content__icontains=search_keyword))
+        # QuerySet 구성
+        queryset = Question.objects.select_related("author", "category__parent__parent")
 
-        category_id = filters.get("category_id")
-        if category_id:
-            queryset = queryset.filter(category_id=category_id)
+        # 필터링 및 정렬
+        queryset = QuestionQueryService._apply_category_filter(queryset, filters.get("category_id"))
+        queryset = QuestionQueryService._apply_search_filter(queryset, filters.get("search_keyword"))
+        queryset = QuestionQueryService._apply_status_filter(queryset, filters.get("answer_status"))
+        queryset = QuestionQueryService._apply_sorting(queryset, filters.get("sort", "latest"))
 
-        answer_status = filters.get("answer_status")
-        if answer_status == "waiting":
-            queryset = queryset.filter(answer_count=0)
-        elif answer_status == "answered":
-            queryset = queryset.filter(answer_count__gt=0)
-
-        sort = filters.get("sort")
-        if sort == "latest":
-            queryset = queryset.order_by("-created_at")
-        elif sort == "oldest":
-            queryset = queryset.order_by("created_at")
-        elif sort == "most_views":
-            queryset = queryset.order_by("-view_count")
-
-        if not queryset.exists():
-            raise QnaBaseException(detail=ErrorMessages.NOT_FOUND_QUESTION_LIST, status_code=status.HTTP_404_NOT_FOUND)
         return queryset
+
+    @staticmethod
+    def _apply_category_filter(queryset: QuerySet[Question], category_id: int | None) -> QuerySet[Question]:
+        if not category_id:
+            return queryset
+
+        # [Guard Clause] DB에 존재하지 않는 카테고리일 경우만 404 발생
+        if not QuestionCategory.objects.filter(id=category_id).exists():
+            raise QnaBaseException(detail=ErrorMessages.NOT_FOUND_QUESTION, status_code=status.HTTP_404_NOT_FOUND)
+
+        return queryset.filter(category_id=category_id)
+
+    @staticmethod
+    def _apply_search_filter(queryset: QuerySet[Question], keyword: str | None) -> QuerySet[Question]:
+        if not keyword:
+            return queryset
+        return queryset.filter(Q(title__icontains=keyword) | Q(content__icontains=keyword))
+
+    @staticmethod
+    def _apply_status_filter(queryset: QuerySet[Question], answer_status: str | None) -> QuerySet[Question]:
+        """답변 상태에 따른 필터링 (성능 최적화 적용)"""
+        if answer_status == "waiting":
+            # [Optimization] Count를 구하는 것보다 역참조 존재 여부를 체크하는 것이 훨씬 빠름
+            return queryset.filter(answers__isnull=True)
+
+        if answer_status == "answered":
+            # 답변이 하나라도 있는 경우 (Distinct를 통한 중복 방지)
+            return queryset.filter(answers__isnull=False).distinct()
+
+        return queryset
+
+    @staticmethod
+    def _apply_sorting(queryset: QuerySet[Question], sort: str) -> QuerySet[Question]:
+        """정렬 전략 분리"""
+        # 정렬 시 created_at과 id를 같이 사용하여 페이징 시 정렬 보장(Stable Sort)
+        sort_map = {
+            "latest": ["-created_at", "-id"],
+            "oldest": ["created_at", "id"],
+            "most_views": ["-view_count", "-created_at"],
+        }
+
+        order_by = sort_map.get(sort, sort_map["latest"])
+
+        # 목록 조회 시점에 답변 개수가 필요하다면 여기서만 annotate (지연 연산)
+        return queryset.annotate(answer_count=Count("answers")).order_by(*order_by)
 
     @staticmethod
     @transaction.atomic

--- a/apps/qna/tests/test_question_list.py
+++ b/apps/qna/tests/test_question_list.py
@@ -161,23 +161,27 @@ class QuestionListAPITest(TestCase):
         response = self.client.get(self.url, {"category_id": 9999})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.json()["error_detail"], ErrorMessages.NOT_FOUND_QUESTION_LIST.value)
+        self.assertEqual(response.json()["error_detail"], ErrorMessages.NOT_FOUND_QUESTION.value)
 
-    def test_search_no_results_returns_404(self) -> None:
-        """[404] 검색 결과가 전혀 없을 경우 404 반환 검증"""
+    def test_search_no_results_returns_empty_list(self) -> None:
+        """[200] 검색 결과가 전혀 없을 경우 200 OK와 빈 리스트 반환 검증"""
         response = self.client.get(self.url, {"search_keyword": "절대로없을법한검색어123"})
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.json()["error_detail"], ErrorMessages.NOT_FOUND_QUESTION_LIST.value)
+        data = response.json()
 
-    def test_filter_status_no_results_returns_404(self) -> None:
-        """[404] 필터 조건에 부합하는 데이터가 없을 경우 404 반환 검증"""
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data["results"]), 0)
+
+    def test_filter_status_no_results_returns_empty_list(self) -> None:
+        """[200] 필터 조건에 부합하는 데이터가 없을 경우 200 OK와 빈 리스트 반환 검증"""
         # q1에 답변을 달아서 모든 질문을 'answered' 상태로 만듦
         Answer.objects.create(author=self.user, question=self.q1, content="답변 추가")
 
-        # 'waiting' 상태를 조회하면 결과가 0건이므로 404 발생
+        # 'waiting' 상태를 조회하면 결과가 0건이지만 200 반환
         response = self.client.get(self.url, {"answer_status": "waiting"})
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.json()["error_detail"], ErrorMessages.NOT_FOUND_QUESTION_LIST.value)
+        data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data["results"]), 0)
 
     # --- 400 Bad Request ---------------------
 
@@ -201,6 +205,14 @@ class QuestionListAPITest(TestCase):
         response = self.client.get(self.url, {"page": "first_page"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["error_detail"], ErrorMessages.INVALID_QUESTION_LIST.value)
+
+    def test_page_out_of_range_returns_404(self) -> None:
+        """[404] 존재하지 않는 페이지 번호 요청 시 404 반환 검증"""
+        # 데이터는 2개(setup), size=10 default -> 2페이지는 없음
+        response = self.client.get(self.url, {"page": 999})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        # DRF 기본 404 메시지 확인 (혹은 커스텀)
+        self.assertEqual(response.json()["error_detail"], ErrorMessages.NOT_FOUND_QUESTION.value)
 
     def test_question_list_performance(self) -> None:
         """[성공] 질문 목록 조회 시 발생하는 쿼리 수 검증"""

--- a/apps/qna/utils/qna_paginator.py
+++ b/apps/qna/utils/qna_paginator.py
@@ -1,9 +1,13 @@
 from typing import Any, Type
 
+from rest_framework import status
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 
 from apps.core.utils.pagination import QnaPagination
+from apps.qna.constants import ErrorMessages
+from apps.qna.exceptions import QnaBaseException
 
 
 class QnAPaginator:
@@ -18,11 +22,19 @@ class QnAPaginator:
         """QuerySet 기반 페이지네이션 응답 객체 생성"""
         # core에 정의된 페이지네이션 인스턴스 생성
         instance = QnaPagination()
-        page = instance.paginate_queryset(queryset, request, view=view)
 
-        if page is not None:
-            serializer = serializer_class(page, many=True)
-            return instance.get_paginated_response(serializer.data)
+        try:
+            # 데이터 분할 및 page_number 검증
+            page = instance.paginate_queryset(queryset, request, view=view)
 
-        serializer = serializer_class(queryset, many=True)
-        return Response(serializer.data)
+            # 페이지네이션이 활성화된 경우 (page가 리스트인 경우)
+            if page is not None:
+                serializer = serializer_class(page, many=True)
+                return instance.get_paginated_response(serializer.data)
+
+            # 페이지네이션이 적용되지 않는 경우 (전체 반환)
+            serializer = serializer_class(queryset, many=True)
+            return Response(serializer.data)
+
+        except NotFound:
+            raise QnaBaseException(detail=ErrorMessages.NOT_FOUND_QUESTION, status_code=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약
  - 프론트 요청-필터링 결과에 따라 기존 404 반환에서 상황에 따라 []도 반환하게 수정
  - 필터링 로직 리팩터링

## 📄 상세 내용
- [x] category id, page 가 존재하지 않는 값이나 범위를 넘어선 값일 때만 error message + 404 반환
- [x] 키워드나, 카테고리, 답변 여부 필터링 시 아무값도 필터링 되지 않았을 경우 [] + 200 반환
- [x] 필터링 로직 개선

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
