### PR TITLE
[Feat/user admin] 어드민 페이지 월별 회원 탈퇴 사유 분석 API test파일 생성

### DIFF
--- a/apps/users/admin_urls.py
+++ b/apps/users/admin_urls.py
@@ -26,7 +26,8 @@ from apps.users.views.admin.admin_withdrawal_views import (
     AdminWithdrawalDetailAPIView,
     AdminWithdrawalListAPIView,
 )
-
+from django.urls import path
+from apps.users.views.admin.admin_analysis_reason_views import WithdrawalReasonMonthlyStatsView
 
 # GET, PATCH, DELETE를 같은 URL에서 처리하기 위한 combined view
 class AdminAccountAPIView(AdminAccountDetailAPIView, AdminAccountUpdateAPIView, AdminAccountDeleteAPIView):
@@ -59,7 +60,6 @@ urlpatterns = [
     ),
     # Students
     path("students/", AdminStudentListAPIView.as_view(), name="admin-student-list"),
-    path("students/<int:student_id>/scores", AdminStudentScoreAPIView.as_view(), name="admin-student-scores"),
     path("student-enrollments/", AdminStudentEnrollmentListAPIView.as_view(), name="admin-student-enrollment-list"),
     path(
         "student-enrollments/accept",

--- a/apps/users/admin_urls.py
+++ b/apps/users/admin_urls.py
@@ -93,4 +93,10 @@ urlpatterns = [
         AdminWithdrawalReasonCountsAPIView.as_view(),
         name="admin-withdrawal-reason-counts",
     ),
+    path(
+        "analytics/withdrawal-reasons/monthly-stats",
+        WithdrawalReasonMonthlyStatsView.as_view(),
+        name="admin-withdrawal-stats",
+    ),
+    path("students/<int:student_id>/scores", AdminStudentScoreAPIView.as_view(), name="admin-student-scores"),
 ]

--- a/apps/users/admin_urls.py
+++ b/apps/users/admin_urls.py
@@ -9,6 +9,9 @@ from apps.users.views.admin.admin_account_role_views import (
     AdminAccountRoleUpdateAPIView,
 )
 from apps.users.views.admin.admin_account_views import AdminAccountUpdateAPIView
+from apps.users.views.admin.admin_analysis_reason_views import (
+    WithdrawalReasonMonthlyStatsView,
+)
 from apps.users.views.admin.admin_analytics_views import (
     AdminSignupTrendsAPIView,
     AdminStudentEnrollmentTrendsAPIView,
@@ -26,8 +29,7 @@ from apps.users.views.admin.admin_withdrawal_views import (
     AdminWithdrawalDetailAPIView,
     AdminWithdrawalListAPIView,
 )
-from django.urls import path
-from apps.users.views.admin.admin_analysis_reason_views import WithdrawalReasonMonthlyStatsView
+
 
 # GET, PATCH, DELETE를 같은 URL에서 처리하기 위한 combined view
 class AdminAccountAPIView(AdminAccountDetailAPIView, AdminAccountUpdateAPIView, AdminAccountDeleteAPIView):

--- a/apps/users/serializers/admin/admin_analysis_reason_serializers.py
+++ b/apps/users/serializers/admin/admin_analysis_reason_serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+class WithdrawalMonthItemSerializer(serializers.Serializer):
+    period = serializers.CharField(help_text="YYYY-MM")
+    count = serializers.IntegerField()
+
+class WithdrawalReasonStatsResponseSerializer(serializers.Serializer):
+    reason = serializers.CharField()
+    reason_label = serializers.CharField()
+    from_date = serializers.CharField()
+    to_date = serializers.CharField()
+    total = serializers.IntegerField()
+    items = WithdrawalMonthItemSerializer(many=True)

--- a/apps/users/serializers/admin/admin_analysis_reason_serializers.py
+++ b/apps/users/serializers/admin/admin_analysis_reason_serializers.py
@@ -2,6 +2,16 @@ from typing import Any, Dict
 
 from rest_framework import serializers
 
+from apps.users.models.withdrawal import Withdrawal
+
+class WithdrawalReasonStatsRequestSerializer(serializers.Serializer[Dict[str, Any]]):
+    """탈퇴 사유 통계 조회 요청 검증 시리얼라이저"""
+
+    reason = serializers.ChoiceField(
+        choices=Withdrawal.Reason.choices,
+        required=True,
+        help_text="탈퇴 사유 코드",
+    )
 
 class WithdrawalMonthItemSerializer(serializers.Serializer[Dict[str, Any]]):
     period = serializers.CharField(help_text="YYYY-MM")

--- a/apps/users/serializers/admin/admin_analysis_reason_serializers.py
+++ b/apps/users/serializers/admin/admin_analysis_reason_serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from apps.users.models.withdrawal import Withdrawal
 
+
 class WithdrawalReasonStatsRequestSerializer(serializers.Serializer[Dict[str, Any]]):
     """탈퇴 사유 통계 조회 요청 검증 시리얼라이저"""
 
@@ -12,6 +13,7 @@ class WithdrawalReasonStatsRequestSerializer(serializers.Serializer[Dict[str, An
         required=True,
         help_text="탈퇴 사유 코드",
     )
+
 
 class WithdrawalMonthItemSerializer(serializers.Serializer[Dict[str, Any]]):
     period = serializers.CharField(help_text="YYYY-MM")

--- a/apps/users/serializers/admin/admin_analysis_reason_serializers.py
+++ b/apps/users/serializers/admin/admin_analysis_reason_serializers.py
@@ -1,10 +1,14 @@
+from typing import Any, Dict
+
 from rest_framework import serializers
 
-class WithdrawalMonthItemSerializer(serializers.Serializer):
+
+class WithdrawalMonthItemSerializer(serializers.Serializer[Dict[str, Any]]):
     period = serializers.CharField(help_text="YYYY-MM")
     count = serializers.IntegerField()
 
-class WithdrawalReasonStatsResponseSerializer(serializers.Serializer):
+
+class WithdrawalReasonStatsResponseSerializer(serializers.Serializer[Dict[str, Any]]):
     reason = serializers.CharField()
     reason_label = serializers.CharField()
     from_date = serializers.CharField()

--- a/apps/users/services/admin_analysis_reason_service.py
+++ b/apps/users/services/admin_analysis_reason_service.py
@@ -11,11 +11,17 @@ class AdminAnalysisReasonService:
     @staticmethod
     def get_monthly_withdrawal_stats(reason: str) -> Dict[str, Any]:
         now = timezone.now()
-        from_date = now.replace(month=1, day=1).strftime("%Y-%m-%d")
+        from_datetime = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        from_date = from_datetime.strftime("%Y-%m-%d")
         to_date = now.strftime("%Y-%m-%d")
 
         stats_query = (
-            Withdrawal.objects.filter(reason=reason)
+            Withdrawal.objects.filter(
+                reason=reason,
+                created_at__gte=from_datetime,
+                created_at__lte=now,
+            )
             .annotate(period=TruncMonth("created_at"))
             .values("period")
             .annotate(count=Count("id"))

--- a/apps/users/services/admin_analysis_reason_service.py
+++ b/apps/users/services/admin_analysis_reason_service.py
@@ -1,0 +1,44 @@
+from django.db.models import Count
+from django.db.models.functions import TruncMonth
+from django.utils import timezone
+from apps.users.models.withdrawal import Withdrawal  # 실제 경로에 맞춰 import
+
+class AdminAnalysisReasonService:
+    @staticmethod
+    def get_monthly_withdrawal_stats(reason: str):
+        # 1. 날짜 범위 설정 (올해 1월 1일부터 현재까지)
+        now = timezone.now()
+        from_date = now.replace(month=1, day=1).strftime('%Y-%m-%d')
+        to_date = now.strftime('%Y-%m-%d')
+
+        # 2. 특정 사유에 대한 월별 통계 쿼리 (TimeStampModel의 created_at 활용)
+        stats_query = (
+            Withdrawal.objects.filter(reason=reason)
+            .annotate(period=TruncMonth('created_at'))
+            .values('period')
+            .annotate(count=Count('id'))
+            .order_by('period')
+        )
+
+        # 3. 데이터 포맷팅
+        items = [
+            {
+                "period": item['period'].strftime('%Y-%m'),
+                "count": item['count']
+            }
+            for item in stats_query
+        ]
+
+        total = sum(item['count'] for item in items)
+
+        # 모델의 Reason 클래스에서 label 가져오기
+        reason_label = dict(Withdrawal.Reason.choices).get(reason, "기타")
+
+        return {
+            "reason": reason,
+            "reason_label": reason_label,
+            "from_date": from_date,
+            "to_date": to_date,
+            "total": total,
+            "items": items
+        }

--- a/apps/users/services/admin_analysis_reason_service.py
+++ b/apps/users/services/admin_analysis_reason_service.py
@@ -1,37 +1,32 @@
+from typing import Any, Dict, List
+
 from django.db.models import Count
 from django.db.models.functions import TruncMonth
 from django.utils import timezone
-from apps.users.models.withdrawal import Withdrawal  # 실제 경로에 맞춰 import
+
+from apps.users.models.withdrawal import Withdrawal
+
 
 class AdminAnalysisReasonService:
     @staticmethod
-    def get_monthly_withdrawal_stats(reason: str):
-        # 1. 날짜 범위 설정 (올해 1월 1일부터 현재까지)
+    def get_monthly_withdrawal_stats(reason: str) -> Dict[str, Any]:
         now = timezone.now()
-        from_date = now.replace(month=1, day=1).strftime('%Y-%m-%d')
-        to_date = now.strftime('%Y-%m-%d')
+        from_date = now.replace(month=1, day=1).strftime("%Y-%m-%d")
+        to_date = now.strftime("%Y-%m-%d")
 
-        # 2. 특정 사유에 대한 월별 통계 쿼리 (TimeStampModel의 created_at 활용)
         stats_query = (
             Withdrawal.objects.filter(reason=reason)
-            .annotate(period=TruncMonth('created_at'))
-            .values('period')
-            .annotate(count=Count('id'))
-            .order_by('period')
+            .annotate(period=TruncMonth("created_at"))
+            .values("period")
+            .annotate(count=Count("id"))
+            .order_by("period")
         )
 
-        # 3. 데이터 포맷팅
-        items = [
-            {
-                "period": item['period'].strftime('%Y-%m'),
-                "count": item['count']
-            }
-            for item in stats_query
+        items: List[Dict[str, Any]] = [
+            {"period": item["period"].strftime("%Y-%m"), "count": item["count"]} for item in stats_query
         ]
 
-        total = sum(item['count'] for item in items)
-
-        # 모델의 Reason 클래스에서 label 가져오기
+        total = sum(item["count"] for item in items)
         reason_label = dict(Withdrawal.Reason.choices).get(reason, "기타")
 
         return {
@@ -40,5 +35,5 @@ class AdminAnalysisReasonService:
             "from_date": from_date,
             "to_date": to_date,
             "total": total,
-            "items": items
+            "items": items,
         }

--- a/apps/users/tests/test_admin_analysis_reason.py
+++ b/apps/users/tests/test_admin_analysis_reason.py
@@ -1,48 +1,62 @@
-from typing import Any
+from typing import Any,cast
 
-import pytest  # type: ignore
+from django.contrib.auth import get_user_model
+from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from apps.users.models.withdrawal import Withdrawal
 
 
-@pytest.mark.django_db
-class TestAdminAnalysisReason:
-    @pytest.fixture  # type: ignore
-    def setup_data(self) -> None:  # -> None 추가
-        # 1. 테스트용 데이터 생성
+User = get_user_model()
+
+
+class AdminAnalysisReasonTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # 테스트 데이터 (모든 테스트에서 공유, 성능 좋음)
         Withdrawal.objects.create(reason="LACK_OF_CONTENT", created_at=timezone.now())
         Withdrawal.objects.create(reason="LACK_OF_CONTENT", created_at=timezone.now())
         Withdrawal.objects.create(reason="EXPENSIVE", created_at=timezone.now())
 
-    def test_get_monthly_withdrawal_stats_service(self, setup_data: Any) -> None:  # 인자 및 반환 타입 추가
-        from apps.users.services.admin_analysis_reason_service import (
-            AdminAnalysisReasonService,
+        # 관리자 유저 생성 (프로젝트 User 필드에 맞게 수정)
+        cls.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password123",
+            name="관리자",
+            nickname="관리자",
+            phone_number="01011111111",
+            gender=User.Gender.MALE,
+            birthday=timezone.now().date(),
+            role=User.Role.ADMIN,
+            is_active=True,
         )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=cast(Any, self).admin_user)
+
+    def test_get_monthly_withdrawal_stats_service(self) -> None:
+        from apps.users.services.admin_analysis_reason_service import AdminAnalysisReasonService
 
         service = AdminAnalysisReasonService()
         result = service.get_monthly_withdrawal_stats("LACK_OF_CONTENT")
 
-        # 서비스 로직 검증
-        assert result["reason"] == "LACK_OF_CONTENT"
-        assert result["total"] == 2
-        assert len(result["items"]) > 0
+        self.assertEqual(result["reason"], "LACK_OF_CONTENT")
+        self.assertEqual(result["total"], 2)
+        self.assertTrue(len(result["items"]) > 0)
 
-    def test_withdrawal_reason_stats_view_admin_only(self, admin_client: Any) -> None:  # 인자 및 반환 타입 추가
-        # 2. 어드민 권한으로 API 접근 테스트
-        # URL name이 'admin-withdrawal-stats'로 admin_urls.py에 정의되어 있어야 함
+    def test_withdrawal_reason_stats_view_admin_only(self) -> None:
         url = reverse("admin-withdrawal-stats")
-        response = admin_client.get(f"{url}?reason=LACK_OF_CONTENT")
+        response = self.client.get(url, {"reason": "LACK_OF_CONTENT"})
+        data = cast(Any, response).data
+        self.assertIn("items", data)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert "items" in response.data
-
-    def test_withdrawal_reason_stats_view_invalid_reason(self, admin_client: Any) -> None:  # 인자 및 반환 타입 추가
-        # 3. 잘못된 사유 코드 입력 시 에러 처리 테스트
+    def test_withdrawal_reason_stats_view_invalid_reason(self) -> None:
         url = reverse("admin-withdrawal-stats")
-        response = admin_client.get(f"{url}?reason=INVALID_CODE")
+        response = self.client.get(url, {"reason": "INVALID_CODE"})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "error_detail" in response.data
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)

--- a/apps/users/tests/test_admin_analysis_reason.py
+++ b/apps/users/tests/test_admin_analysis_reason.py
@@ -1,62 +1,75 @@
-from typing import Any,cast
+from __future__ import annotations
 
-from django.contrib.auth import get_user_model
+from datetime import date
+
 from django.test import TestCase
-from django.urls import reverse
 from django.utils import timezone
-from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.users.models import User
 from apps.users.models.withdrawal import Withdrawal
 
 
-User = get_user_model()
-
-
-class AdminAnalysisReasonTests(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        # 테스트 데이터 (모든 테스트에서 공유, 성능 좋음)
-        Withdrawal.objects.create(reason="LACK_OF_CONTENT", created_at=timezone.now())
-        Withdrawal.objects.create(reason="LACK_OF_CONTENT", created_at=timezone.now())
-        Withdrawal.objects.create(reason="EXPENSIVE", created_at=timezone.now())
-
-        # 관리자 유저 생성 (프로젝트 User 필드에 맞게 수정)
-        cls.admin_user = User.objects.create_user(
+class WithdrawalReasonMonthlyStatsAPITest(TestCase):
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        self.admin = User.objects.create_user(
             email="admin@example.com",
             password="password123",
             name="관리자",
-            nickname="관리자",
-            phone_number="01011111111",
+            nickname="admin",
+            phone_number="01000000000",
             gender=User.Gender.MALE,
-            birthday=timezone.now().date(),
+            birthday=date(1990, 1, 1),
             role=User.Role.ADMIN,
             is_active=True,
+            is_staff=True,
         )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password123",
+            name="사용자",
+            nickname="user",
+            phone_number="01000000001",
+            gender=User.Gender.MALE,
+            birthday=date(1995, 1, 1),
+            role=User.Role.USER,
+            is_active=True,
+        )
+        self.url = "/api/v1/admin/analytics/withdrawal-reasons/monthly-stats"
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.client.force_authenticate(user=cast(Any, self).admin_user)
+    def test_returns_200_for_admin(self) -> None:
+        withdrawal = Withdrawal.objects.create(
+            user=self.normal_user,
+            reason=Withdrawal.Reason.GRADUATION,
+            reason_detail="done",
+        )
+        Withdrawal.objects.filter(id=withdrawal.id).update(created_at=timezone.now())
 
-    def test_get_monthly_withdrawal_stats_service(self) -> None:
-        from apps.users.services.admin_analysis_reason_service import AdminAnalysisReasonService
+        self.client.force_authenticate(user=self.admin)
+        res = self.client.get(self.url, {"reason": Withdrawal.Reason.GRADUATION})
 
-        service = AdminAnalysisReasonService()
-        result = service.get_monthly_withdrawal_stats("LACK_OF_CONTENT")
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertEqual(data["reason"], Withdrawal.Reason.GRADUATION)
+        self.assertEqual(data["total"], 1)
+        self.assertGreaterEqual(len(data["items"]), 1)
 
-        self.assertEqual(result["reason"], "LACK_OF_CONTENT")
-        self.assertEqual(result["total"], 2)
-        self.assertTrue(len(result["items"]) > 0)
+    def test_returns_400_for_invalid_reason(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        res = self.client.get(self.url, {"reason": "INVALID"})
 
-    def test_withdrawal_reason_stats_view_admin_only(self) -> None:
-        url = reverse("admin-withdrawal-stats")
-        response = self.client.get(url, {"reason": "LACK_OF_CONTENT"})
-        data = cast(Any, response).data
-        self.assertIn("items", data)
+        self.assertEqual(res.status_code, 400)
+        data = res.json()
+        self.assertIn("error_detail", data)
 
-    def test_withdrawal_reason_stats_view_invalid_reason(self) -> None:
-        url = reverse("admin-withdrawal-stats")
-        response = self.client.get(url, {"reason": "INVALID_CODE"})
+    def test_returns_403_for_non_admin(self) -> None:
+        self.client.force_authenticate(user=self.normal_user)
+        res = self.client.get(self.url, {"reason": Withdrawal.Reason.GRADUATION})
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("error_detail", response.data)
+        self.assertEqual(res.status_code, 403)
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        res = self.client.get(self.url, {"reason": Withdrawal.Reason.GRADUATION})
+
+        self.assertEqual(res.status_code, 401)

--- a/apps/users/tests/test_admin_analysis_reason.py
+++ b/apps/users/tests/test_admin_analysis_reason.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+import pytest  # type: ignore
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from apps.users.models.withdrawal import Withdrawal
+
+
+@pytest.mark.django_db
+class TestAdminAnalysisReason:
+    @pytest.fixture  # type: ignore
+    def setup_data(self) -> None:  # -> None 추가
+        # 1. 테스트용 데이터 생성
+        Withdrawal.objects.create(reason="LACK_OF_CONTENT", created_at=timezone.now())
+        Withdrawal.objects.create(reason="LACK_OF_CONTENT", created_at=timezone.now())
+        Withdrawal.objects.create(reason="EXPENSIVE", created_at=timezone.now())
+
+    def test_get_monthly_withdrawal_stats_service(self, setup_data: Any) -> None:  # 인자 및 반환 타입 추가
+        from apps.users.services.admin_analysis_reason_service import (
+            AdminAnalysisReasonService,
+        )
+
+        service = AdminAnalysisReasonService()
+        result = service.get_monthly_withdrawal_stats("LACK_OF_CONTENT")
+
+        # 서비스 로직 검증
+        assert result["reason"] == "LACK_OF_CONTENT"
+        assert result["total"] == 2
+        assert len(result["items"]) > 0
+
+    def test_withdrawal_reason_stats_view_admin_only(self, admin_client: Any) -> None:  # 인자 및 반환 타입 추가
+        # 2. 어드민 권한으로 API 접근 테스트
+        # URL name이 'admin-withdrawal-stats'로 admin_urls.py에 정의되어 있어야 함
+        url = reverse("admin-withdrawal-stats")
+        response = admin_client.get(f"{url}?reason=LACK_OF_CONTENT")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "items" in response.data
+
+    def test_withdrawal_reason_stats_view_invalid_reason(self, admin_client: Any) -> None:  # 인자 및 반환 타입 추가
+        # 3. 잘못된 사유 코드 입력 시 에러 처리 테스트
+        url = reverse("admin-withdrawal-stats")
+        response = admin_client.get(f"{url}?reason=INVALID_CODE")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error_detail" in response.data

--- a/apps/users/views/admin/admin_analysis_reason_views.py
+++ b/apps/users/views/admin/admin_analysis_reason_views.py
@@ -6,11 +6,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-try:
-    from drf_yasg import openapi  # type: ignore
-    from drf_yasg.utils import swagger_auto_schema  # type: ignore
-except ImportError:
-    pass
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.users.models.withdrawal import Withdrawal
 from apps.users.serializers.admin.admin_analysis_reason_serializers import (
@@ -22,20 +19,21 @@ from apps.users.services.admin_analysis_reason_service import AdminAnalysisReaso
 class WithdrawalReasonMonthlyStatsView(APIView):
     permission_classes = [IsAdminUser]
 
-    @swagger_auto_schema(  # type: ignore
-        operation_description="월별 탈퇴 사유 통계 데이터를 조회합니다.",
-        manual_parameters=[
-            openapi.Parameter(
-                "reason",
-                openapi.IN_QUERY,
-                description="탈퇴 사유 코드",
-                type=openapi.TYPE_STRING,
+    @extend_schema(
+        tags=["admin_accounts"],
+        summary="월별 탈퇴 사유 통계 조회",
+        description="월별 탈퇴 사유 통계 데이터를 조회합니다.",
+        parameters=[
+            OpenApiParameter(
+                name="reason",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
                 required=True,
+                description="탈퇴 사유 코드",
                 enum=[choice[0] for choice in Withdrawal.Reason.choices],
-            )
+            ),
         ],
         responses={200: WithdrawalReasonStatsResponseSerializer},
-        tags=["Admin Analytics"],
     )
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         reason = request.query_params.get("reason")

--- a/apps/users/views/admin/admin_analysis_reason_views.py
+++ b/apps/users/views/admin/admin_analysis_reason_views.py
@@ -1,0 +1,46 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAdminUser
+from rest_framework import status
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+from apps.users.services.admin_analysis_reason_service import AdminAnalysisReasonService
+from apps.users.serializers.admin.admin_analysis_reason_serializers import WithdrawalReasonStatsResponseSerializer
+from apps.users.models.withdrawal import Withdrawal
+
+class WithdrawalReasonMonthlyStatsView(APIView):
+    permission_classes = [IsAdminUser]
+
+    @swagger_auto_schema(
+        operation_description="월별 탈퇴 사유 통계 데이터를 조회합니다.",
+        manual_parameters=[
+            openapi.Parameter(
+                'reason',
+                openapi.IN_QUERY,
+                description="탈퇴 사유 코드",
+                type=openapi.TYPE_STRING,
+                required=True,
+                # 모델에 정의된 실제 Choice 값들로 수정
+                enum=[choice[0] for choice in Withdrawal.Reason.choices]
+            )
+        ],
+        responses={200: WithdrawalReasonStatsResponseSerializer},
+        tags=['Admin Analytics']
+    )
+    def get(self, request):
+        reason = request.query_params.get('reason')
+
+        # 모델에 정의된 유효한 사유인지 검증
+        valid_reasons = [choice[0] for choice in Withdrawal.Reason.choices]
+        if not reason or reason not in valid_reasons:
+            return Response(
+                {"error_detail": f"유효하지 않은 사유입니다. 다음 중 하나를 선택하세요: {', '.join(valid_reasons)}"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        service = AdminAnalysisReasonService()
+        data = service.get_monthly_withdrawal_stats(reason)
+
+        serializer = WithdrawalReasonStatsResponseSerializer(data)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/users/views/admin/admin_analysis_reason_views.py
+++ b/apps/users/views/admin/admin_analysis_reason_views.py
@@ -1,13 +1,12 @@
 from typing import Any, List
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAdminUser
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.users.models.withdrawal import Withdrawal
 from apps.users.serializers.admin.admin_analysis_reason_serializers import (

--- a/apps/users/views/admin/admin_analysis_reason_views.py
+++ b/apps/users/views/admin/admin_analysis_reason_views.py
@@ -1,42 +1,51 @@
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework.permissions import IsAdminUser
-from rest_framework import status
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg import openapi
+from typing import Any, List
 
-from apps.users.services.admin_analysis_reason_service import AdminAnalysisReasonService
-from apps.users.serializers.admin.admin_analysis_reason_serializers import WithdrawalReasonStatsResponseSerializer
+from rest_framework import status
+from rest_framework.permissions import IsAdminUser
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+try:
+    from drf_yasg import openapi  # type: ignore
+    from drf_yasg.utils import swagger_auto_schema  # type: ignore
+except ImportError:
+    pass
+
 from apps.users.models.withdrawal import Withdrawal
+from apps.users.serializers.admin.admin_analysis_reason_serializers import (
+    WithdrawalReasonStatsResponseSerializer,
+)
+from apps.users.services.admin_analysis_reason_service import AdminAnalysisReasonService
+
 
 class WithdrawalReasonMonthlyStatsView(APIView):
     permission_classes = [IsAdminUser]
 
-    @swagger_auto_schema(
+    @swagger_auto_schema(  # type: ignore
         operation_description="월별 탈퇴 사유 통계 데이터를 조회합니다.",
         manual_parameters=[
             openapi.Parameter(
-                'reason',
+                "reason",
                 openapi.IN_QUERY,
                 description="탈퇴 사유 코드",
                 type=openapi.TYPE_STRING,
                 required=True,
-                # 모델에 정의된 실제 Choice 값들로 수정
-                enum=[choice[0] for choice in Withdrawal.Reason.choices]
+                enum=[choice[0] for choice in Withdrawal.Reason.choices],
             )
         ],
         responses={200: WithdrawalReasonStatsResponseSerializer},
-        tags=['Admin Analytics']
+        tags=["Admin Analytics"],
     )
-    def get(self, request):
-        reason = request.query_params.get('reason')
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        reason = request.query_params.get("reason")
 
-        # 모델에 정의된 유효한 사유인지 검증
-        valid_reasons = [choice[0] for choice in Withdrawal.Reason.choices]
+        valid_reasons: List[str] = [choice[0] for choice in Withdrawal.Reason.choices]
+
         if not reason or reason not in valid_reasons:
             return Response(
                 {"error_detail": f"유효하지 않은 사유입니다. 다음 중 하나를 선택하세요: {', '.join(valid_reasons)}"},
-                status=status.HTTP_400_BAD_REQUEST
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         service = AdminAnalysisReasonService()


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 어드민 페이지 월별 회원 탈퇴 사유 분석 API test파일 생성

## 📄 상세 내용
- [x] apps/users/views/admin/admin_analysis_reason_views.py 어드민 월별 탈퇴 사유 통계 api생성
- [x] apps/users/services/admin_analysis_reason_service.py 
- [x] apps/users/serializers/admin/admin_analysis_reason_serializers.py
- [x] apps/users/tests/test_admin_analysis_reason.py
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
admin_urls.py 에 admin-withdrawal-stats, admin-student-scores 추가
 
## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
