### PR TITLE
[refactor/exams-exception-handling] ♻️ exams 예외 처리 중앙화 및 서비스 책임 강화

### DIFF
--- a/apps/exams/services/admin/deployments_create.py
+++ b/apps/exams/services/admin/deployments_create.py
@@ -3,18 +3,13 @@ from typing import Any
 from uuid import uuid4
 
 from django.db import transaction
+from rest_framework import status
 
 from apps.core.utils.base62 import Base62
 from apps.courses.models.cohorts import Cohort
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import Exam, ExamDeployment, ExamQuestion
-
-
-class ExamDeploymentNotFoundError(Exception):
-    """배포 대상 정보를 찾지 못했을 때 발생."""
-
-
-class ExamDeploymentConflictError(Exception):
-    """배포 생성 중 중복/충돌 발생 시."""
 
 
 def _generate_access_code() -> str:
@@ -61,7 +56,7 @@ def create_exam_deployment(payload: dict[str, Any]) -> int:
     exam = Exam.objects.filter(id=exam_id).first()
     cohort = Cohort.objects.filter(id=cohort_id).first()
     if not exam or not cohort:
-        raise ExamDeploymentNotFoundError
+        raise ErrorDetailException(ErrorMessages.DEPLOYMENT_TARGET_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
 
     with transaction.atomic():
         if ExamDeployment.objects.filter(
@@ -70,7 +65,7 @@ def create_exam_deployment(payload: dict[str, Any]) -> int:
             open_at=open_at,
             close_at=close_at,
         ).exists():
-            raise ExamDeploymentConflictError
+            raise ErrorDetailException(ErrorMessages.DUPLICATE_DEPLOYMENT.value, status.HTTP_409_CONFLICT)
 
         snapshot = _build_question_snapshot(exam)
         access_code = _generate_access_code()

--- a/apps/exams/services/admin/deployments_detail.py
+++ b/apps/exams/services/admin/deployments_detail.py
@@ -1,11 +1,11 @@
 from typing import Any
 
+from rest_framework import status
+
 from apps.courses.models.cohort_students import CohortStudent
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamDeployment
-
-
-class ExamDeploymentDetailNotFoundError(Exception):
-    """배포 상세 조회 대상이 없을 때 발생."""
 
 
 def get_exam_deployment_detail(deployment_id: int) -> dict[str, Any]:
@@ -13,7 +13,7 @@ def get_exam_deployment_detail(deployment_id: int) -> dict[str, Any]:
         ExamDeployment.objects.select_related("exam__subject", "cohort__course").filter(id=deployment_id).first()
     )
     if not deployment:
-        raise ExamDeploymentDetailNotFoundError
+        raise ErrorDetailException(ErrorMessages.DEPLOYMENT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
 
     submitted_count = deployment.submissions.values("submitter_id").distinct().count()
     total_students = CohortStudent.objects.filter(cohort_id=deployment.cohort_id).count()

--- a/apps/exams/services/admin/deployments_status.py
+++ b/apps/exams/services/admin/deployments_status.py
@@ -1,14 +1,9 @@
 from django.db import transaction
+from rest_framework import status
 
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamDeployment
-
-
-class ExamDeploymentStatusNotFoundError(Exception):
-    """배포 정보를 찾지 못했을 때 발생."""
-
-
-class ExamDeploymentStatusConflictError(Exception):
-    """배포 상태 변경 중 충돌 발생 시."""
 
 
 def update_deployment_status(deployment_id: int, status: str) -> ExamDeployment:
@@ -16,7 +11,7 @@ def update_deployment_status(deployment_id: int, status: str) -> ExamDeployment:
         try:
             deployment = ExamDeployment.objects.select_for_update().get(id=deployment_id)
         except ExamDeployment.DoesNotExist as exc:
-            raise ExamDeploymentStatusNotFoundError from exc
+            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
 
         new_status = (
             ExamDeployment.StatusChoices.ACTIVATED
@@ -27,6 +22,6 @@ def update_deployment_status(deployment_id: int, status: str) -> ExamDeployment:
         try:
             deployment.save(update_fields=["status"])
         except Exception as exc:
-            raise ExamDeploymentStatusConflictError from exc
+            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
 
     return deployment

--- a/apps/exams/services/admin/deployments_status.py
+++ b/apps/exams/services/admin/deployments_status.py
@@ -6,7 +6,7 @@ from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamDeployment
 
 
-def update_deployment_status(deployment_id: int, status: str) -> ExamDeployment:
+def update_deployment_status(deployment_id: int, status_value: str) -> ExamDeployment:
     with transaction.atomic():
         try:
             deployment = ExamDeployment.objects.select_for_update().get(id=deployment_id)
@@ -15,7 +15,7 @@ def update_deployment_status(deployment_id: int, status: str) -> ExamDeployment:
 
         new_status = (
             ExamDeployment.StatusChoices.ACTIVATED
-            if status == "activated"
+            if status_value == "activated"
             else ExamDeployment.StatusChoices.DEACTIVATED
         )
         deployment.status = new_status

--- a/apps/exams/services/admin/deployments_update.py
+++ b/apps/exams/services/admin/deployments_update.py
@@ -1,17 +1,17 @@
 from typing import Any
 
+from rest_framework import status
+
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamDeployment
-
-
-class ExamDeploymentUpdateNotFoundError(Exception):
-    """수정할 배포 정보를 찾지 못했을 때 발생."""
 
 
 def update_exam_deployment(deployment_id: int, validated_data: dict[str, Any]) -> ExamDeployment:
     try:
         deployment = ExamDeployment.objects.get(id=deployment_id)
     except ExamDeployment.DoesNotExist as exc:
-        raise ExamDeploymentUpdateNotFoundError from exc
+        raise ErrorDetailException(ErrorMessages.DEPLOYMENT_UPDATE_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
 
     deployment.open_at = validated_data["open_at"]
     deployment.close_at = validated_data["close_at"]

--- a/apps/exams/services/admin/exams_create.py
+++ b/apps/exams/services/admin/exams_create.py
@@ -6,17 +6,12 @@ from uuid import uuid4
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
+from rest_framework import status
 
 from apps.courses.models.subjects import Subject
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models.exams import Exam
-
-
-class ExamCreateConflictError(Exception):
-    """동일한 시험명이 이미 존재할 때 발생."""
-
-
-class ExamCreateNotFoundError(Exception):
-    """과목 정보가 없을 때 발생."""
 
 
 def _store_thumbnail(thumbnail_img: UploadedFile) -> tuple[str, str]:
@@ -32,7 +27,7 @@ def create_exam(title: str, subject_id: int, thumbnail_img: UploadedFile | None)
     with transaction.atomic():
         subject = Subject.objects.filter(id=subject_id).first()
         if not subject:
-            raise ExamCreateNotFoundError
+            raise ErrorDetailException(ErrorMessages.SUBJECT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
 
         saved_path = None
         thumbnail_img_url = None
@@ -47,7 +42,7 @@ def create_exam(title: str, subject_id: int, thumbnail_img: UploadedFile | None)
                 },
             )
             if not created:
-                raise ExamCreateConflictError
+                raise ErrorDetailException(ErrorMessages.EXAM_CONFLICT.value, status.HTTP_409_CONFLICT)
             return exam
         except Exception:
             if saved_path:

--- a/apps/exams/services/admin/exams_delete.py
+++ b/apps/exams/services/admin/exams_delete.py
@@ -1,26 +1,21 @@
 from django.db import transaction
+from rest_framework import status
 
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import Exam
-
-
-class ExamDeleteNotFoundError(Exception):
-    """삭제 대상 쪽지시험을 찾지 못했을 때 발생."""
-
-
-class ExamDeleteConflictError(Exception):
-    """쪽지시험 삭제 중 충돌 발생 시."""
 
 
 def delete_exam(exam_id: int) -> int:
     try:
         exam = Exam.objects.get(id=exam_id)
     except Exam.DoesNotExist as exc:
-        raise ExamDeleteNotFoundError from exc
+        raise ErrorDetailException(ErrorMessages.EXAM_DELETE_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
 
     try:
         with transaction.atomic():
             exam.delete()
     except Exception as exc:
-        raise ExamDeleteConflictError from exc
+        raise ErrorDetailException(ErrorMessages.EXAM_DELETE_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
 
     return exam_id

--- a/apps/exams/services/admin/questions_create.py
+++ b/apps/exams/services/admin/questions_create.py
@@ -3,16 +3,11 @@ from typing import Any
 
 from django.db import transaction
 from django.db.models import Count, Sum
+from rest_framework import status
 
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import Exam, ExamQuestion
-
-
-class ExamNotFoundError(Exception):
-    """쪽지시험 정보가 없을 때 발생."""
-
-
-class ExamQuestionLimitError(Exception):
-    """문항 수/총점 제한을 초과했을 때 발생."""
 
 
 def create_exam_question(exam_id: int, payload: dict[str, Any]) -> dict[str, Any]:
@@ -20,16 +15,16 @@ def create_exam_question(exam_id: int, payload: dict[str, Any]) -> dict[str, Any
         try:
             exam = Exam.objects.select_for_update().get(id=exam_id)
         except Exam.DoesNotExist as exc:
-            raise ExamNotFoundError from exc
+            raise ErrorDetailException(ErrorMessages.EXAM_ADMIN_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
 
         stats = exam.questions.aggregate(count=Count("id"), total=Sum("point"))
         question_count = stats["count"] or 0
         total_points = stats["total"] or 0
         if question_count >= 20:
-            raise ExamQuestionLimitError
+            raise ErrorDetailException(ErrorMessages.QUESTION_CREATE_CONFLICT.value, status.HTTP_409_CONFLICT)
         point = payload["point"]
         if total_points + point > 100:
-            raise ExamQuestionLimitError
+            raise ErrorDetailException(ErrorMessages.QUESTION_CREATE_CONFLICT.value, status.HTTP_409_CONFLICT)
 
         options = payload.get("options")
         blank_count = payload.get("blank_count")

--- a/apps/exams/services/admin/questions_delete.py
+++ b/apps/exams/services/admin/questions_delete.py
@@ -1,25 +1,20 @@
 from django.db import transaction
+from rest_framework import status
 
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamQuestion
-
-
-class ExamQuestionDeleteNotFoundError(Exception):
-    """삭제 대상 문제를 찾지 못했을 때 발생."""
-
-
-class ExamQuestionDeleteConflictError(Exception):
-    """문제 삭제 중 충돌 발생 시."""
 
 
 def delete_exam_question(question_id: int) -> dict[str, int]:
     question = ExamQuestion.objects.filter(id=question_id).first()
     if not question:
-        raise ExamQuestionDeleteNotFoundError
+        raise ErrorDetailException(ErrorMessages.QUESTION_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
 
     try:
         with transaction.atomic():
             question.delete()
     except Exception as exc:
-        raise ExamQuestionDeleteConflictError from exc
+        raise ErrorDetailException(ErrorMessages.QUESTION_DELETE_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
 
     return {"exam_id": question.exam_id, "question_id": question_id}

--- a/apps/exams/services/admin/submissions_delete.py
+++ b/apps/exams/services/admin/submissions_delete.py
@@ -1,25 +1,20 @@
 from django.db import transaction
+from rest_framework import status
 
+from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamSubmission
-
-
-class ExamSubmissionDeleteNotFoundError(Exception):
-    """삭제할 응시 내역을 찾지 못했을 때 발생."""
-
-
-class ExamSubmissionDeleteConflictError(Exception):
-    """응시 내역 삭제 중 충돌 발생 시."""
 
 
 def delete_exam_submission(submission_id: int) -> dict[str, int]:
     submission = ExamSubmission.objects.filter(id=submission_id).first()
     if not submission:
-        raise ExamSubmissionDeleteNotFoundError
+        raise ErrorDetailException(ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
 
     try:
         with transaction.atomic():
             submission.delete()
     except Exception as exc:
-        raise ExamSubmissionDeleteConflictError from exc
+        raise ErrorDetailException(ErrorMessages.SUBMISSION_DELETE_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
 
     return {"submission_id": submission_id}

--- a/apps/exams/views/admin/deployments_create.py
+++ b/apps/exams/views/admin/deployments_create.py
@@ -16,11 +16,7 @@ from apps.exams.serializers.admin.deployments_create import (
     AdminExamDeploymentCreateResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.deployments_create import (
-    ExamDeploymentConflictError,
-    ExamDeploymentNotFoundError,
-    create_exam_deployment,
-)
+from apps.exams.services.admin.deployments_create import create_exam_deployment
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -102,15 +98,7 @@ class AdminExamDeploymentCreateAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            deployment_id = create_exam_deployment(serializer.validated_data)
-        except ExamDeploymentNotFoundError as exc:
-            raise ErrorDetailException(
-                ErrorMessages.DEPLOYMENT_TARGET_NOT_FOUND.value,
-                status.HTTP_404_NOT_FOUND,
-            ) from exc
-        except ExamDeploymentConflictError as exc:
-            raise ErrorDetailException(ErrorMessages.DUPLICATE_DEPLOYMENT.value, status.HTTP_409_CONFLICT) from exc
+        deployment_id = create_exam_deployment(serializer.validated_data)
 
         response_serializer = AdminExamDeploymentCreateResponseSerializer(data={"pk": deployment_id})
         response_serializer.is_valid(raise_exception=True)

--- a/apps/exams/views/admin/deployments_create.py
+++ b/apps/exams/views/admin/deployments_create.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.deployments_create import (
     AdminExamDeploymentCreateRequestSerializer,
     AdminExamDeploymentCreateResponseSerializer,
@@ -96,23 +97,20 @@ class AdminExamDeploymentCreateAPIView(ExamsExceptionMixin, APIView):
     def post(self, request: Request) -> Response:
         serializer = self.serializer_class(data=request.data)
         if not serializer.is_valid():
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_CREATE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_DEPLOYMENT_CREATE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             deployment_id = create_exam_deployment(serializer.validated_data)
-        except ExamDeploymentNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.DEPLOYMENT_TARGET_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except ExamDeploymentConflictError:
-            return Response(
-                {"error_detail": ErrorMessages.DUPLICATE_DEPLOYMENT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+        except ExamDeploymentNotFoundError as exc:
+            raise ErrorDetailException(
+                ErrorMessages.DEPLOYMENT_TARGET_NOT_FOUND.value,
+                status.HTTP_404_NOT_FOUND,
+            ) from exc
+        except ExamDeploymentConflictError as exc:
+            raise ErrorDetailException(ErrorMessages.DUPLICATE_DEPLOYMENT.value, status.HTTP_409_CONFLICT) from exc
 
         response_serializer = AdminExamDeploymentCreateResponseSerializer(data={"pk": deployment_id})
         response_serializer.is_valid(raise_exception=True)

--- a/apps/exams/views/admin/deployments_detail.py
+++ b/apps/exams/views/admin/deployments_detail.py
@@ -11,6 +11,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.deployments_detail import (
     AdminExamDeploymentDetailResponseSerializer,
 )
@@ -97,18 +98,15 @@ class AdminExamDeploymentDetailAPIView(ExamsExceptionMixin, APIView):
 
     def get(self, request: Request, deployment_id: int) -> Response:
         if deployment_id <= 0:
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_DETAIL_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_DEPLOYMENT_DETAIL_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             payload = get_exam_deployment_detail(deployment_id)
-        except ExamDeploymentDetailNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.DEPLOYMENT_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        except ExamDeploymentDetailNotFoundError as exc:
+            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
 
         access_url = request.build_absolute_uri(reverse("exams:take-exam", kwargs={"deployment_id": deployment_id}))
         payload["exam_access_url"] = access_url

--- a/apps/exams/views/admin/deployments_detail.py
+++ b/apps/exams/views/admin/deployments_detail.py
@@ -20,12 +20,8 @@ from apps.exams.serializers.admin.deployments_update import (
     AdminExamDeploymentUpdateResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-<<<<<<< HEAD
 from apps.exams.services.admin.deployments_detail import get_exam_deployment_detail
-from apps.exams.services.admin.deployments_update import (
-    ExamDeploymentUpdateNotFoundError,
-    update_exam_deployment,
-)
+from apps.exams.services.admin.deployments_update import update_exam_deployment
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -174,13 +170,7 @@ class AdminExamDeploymentDetailAPIView(ExamsExceptionMixin, APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            deployment = update_exam_deployment(deployment_id, serializer.validated_data)
-        except ExamDeploymentUpdateNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.DEPLOYMENT_UPDATE_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        deployment = update_exam_deployment(deployment_id, serializer.validated_data)
 
         response_serializer = AdminExamDeploymentUpdateResponseSerializer(
             {

--- a/apps/exams/views/admin/deployments_detail.py
+++ b/apps/exams/views/admin/deployments_detail.py
@@ -20,10 +20,8 @@ from apps.exams.serializers.admin.deployments_update import (
     AdminExamDeploymentUpdateResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.deployments_detail import (
-    ExamDeploymentDetailNotFoundError,
-    get_exam_deployment_detail,
-)
+<<<<<<< HEAD
+from apps.exams.services.admin.deployments_detail import get_exam_deployment_detail
 from apps.exams.services.admin.deployments_update import (
     ExamDeploymentUpdateNotFoundError,
     update_exam_deployment,
@@ -103,10 +101,7 @@ class AdminExamDeploymentDetailAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            payload = get_exam_deployment_detail(deployment_id)
-        except ExamDeploymentDetailNotFoundError as exc:
-            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
+        payload = get_exam_deployment_detail(deployment_id)
 
         access_url = request.build_absolute_uri(reverse("exams:take-exam", kwargs={"deployment_id": deployment_id}))
         payload["exam_access_url"] = access_url

--- a/apps/exams/views/admin/deployments_status.py
+++ b/apps/exams/views/admin/deployments_status.py
@@ -16,11 +16,7 @@ from apps.exams.serializers.admin.deployments_status import (
     AdminExamDeploymentStatusResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.deployments_status import (
-    ExamDeploymentStatusConflictError,
-    ExamDeploymentStatusNotFoundError,
-    update_deployment_status,
-)
+from apps.exams.services.admin.deployments_status import update_deployment_status
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -102,12 +98,7 @@ class AdminExamDeploymentStatusAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            deployment = update_deployment_status(deployment_id, serializer.validated_data["status"])
-        except ExamDeploymentStatusNotFoundError as exc:
-            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
-        except ExamDeploymentStatusConflictError as exc:
-            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
+        deployment = update_deployment_status(deployment_id, serializer.validated_data["status"])
 
         response_serializer = AdminExamDeploymentStatusResponseSerializer(
             {

--- a/apps/exams/views/admin/deployments_status.py
+++ b/apps/exams/views/admin/deployments_status.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.deployments_status import (
     AdminExamDeploymentStatusRequestSerializer,
     AdminExamDeploymentStatusResponseSerializer,
@@ -96,23 +97,17 @@ class AdminExamDeploymentStatusAPIView(ExamsExceptionMixin, APIView):
     def patch(self, request: Request, deployment_id: int) -> Response:
         serializer = self.serializer_class(data=request.data)
         if not serializer.is_valid():
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_DEPLOYMENT_STATUS_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_DEPLOYMENT_STATUS_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             deployment = update_deployment_status(deployment_id, serializer.validated_data["status"])
-        except ExamDeploymentStatusNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.DEPLOYMENT_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except ExamDeploymentStatusConflictError:
-            return Response(
-                {"error_detail": ErrorMessages.DEPLOYMENT_CONFLICT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+        except ExamDeploymentStatusNotFoundError as exc:
+            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
+        except ExamDeploymentStatusConflictError as exc:
+            raise ErrorDetailException(ErrorMessages.DEPLOYMENT_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
 
         response_serializer = AdminExamDeploymentStatusResponseSerializer(
             {

--- a/apps/exams/views/admin/exams_create.py
+++ b/apps/exams/views/admin/exams_create.py
@@ -17,11 +17,7 @@ from apps.exams.serializers.admin.exams_create import (
     AdminExamCreateRequestSerializer,
     AdminExamCreateResponseSerializer,
 )
-from apps.exams.services.admin.exams_create import (
-    ExamCreateConflictError,
-    ExamCreateNotFoundError,
-    create_exam,
-)
+from apps.exams.services.admin.exams_create import create_exam
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -47,16 +43,11 @@ class AdminExamCreateAPIView(ExamsExceptionMixin, APIView):
             )
 
         data = serializer.validated_data
-        try:
-            exam = create_exam(
-                title=data["title"],
-                subject_id=data["subject_id"],
-                thumbnail_img=data.get("thumbnail_img"),
-            )
-        except ExamCreateNotFoundError:
-            raise ErrorDetailException(ErrorMessages.SUBJECT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
-        except ExamCreateConflictError:
-            raise ErrorDetailException(ErrorMessages.EXAM_CONFLICT.value, status.HTTP_409_CONFLICT)
+        exam = create_exam(
+            title=data["title"],
+            subject_id=data["subject_id"],
+            thumbnail_img=data.get("thumbnail_img"),
+        )
 
         response_serializer = AdminExamCreateResponseSerializer(exam)
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin/exams_create.py
+++ b/apps/exams/views/admin/exams_create.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.exams_create import (
     AdminExamCreateRequestSerializer,
     AdminExamCreateResponseSerializer,
@@ -40,9 +41,9 @@ class AdminExamCreateAPIView(ExamsExceptionMixin, APIView):
         serializer = AdminExamCreateRequestSerializer(data=request.data)
 
         if not serializer.is_valid():
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_EXAM_CREATE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_EXAM_CREATE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         data = serializer.validated_data
@@ -53,15 +54,9 @@ class AdminExamCreateAPIView(ExamsExceptionMixin, APIView):
                 thumbnail_img=data.get("thumbnail_img"),
             )
         except ExamCreateNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.SUBJECT_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            raise ErrorDetailException(ErrorMessages.SUBJECT_NOT_FOUND.value, status.HTTP_404_NOT_FOUND)
         except ExamCreateConflictError:
-            return Response(
-                {"error_detail": ErrorMessages.EXAM_CONFLICT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+            raise ErrorDetailException(ErrorMessages.EXAM_CONFLICT.value, status.HTTP_409_CONFLICT)
 
         response_serializer = AdminExamCreateResponseSerializer(exam)
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin/exams_detail.py
+++ b/apps/exams/views/admin/exams_detail.py
@@ -17,11 +17,7 @@ from apps.exams.serializers.admin.exams_update import (
     AdminExamUpdateResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.exams_delete import (
-    ExamDeleteConflictError,
-    ExamDeleteNotFoundError,
-    delete_exam,
-)
+from apps.exams.services.admin.exams_delete import delete_exam
 from apps.exams.services.admin.exams_update import update_exam
 from apps.exams.views.mixins import ExamsExceptionMixin
 
@@ -181,12 +177,7 @@ class AdminExamDetailAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            deleted_id = delete_exam(exam_id)
-        except ExamDeleteNotFoundError as exc:
-            raise ErrorDetailException(ErrorMessages.EXAM_DELETE_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
-        except ExamDeleteConflictError as exc:
-            raise ErrorDetailException(ErrorMessages.EXAM_DELETE_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
+        deleted_id = delete_exam(exam_id)
 
         serializer = AdminExamDeleteResponseSerializer({"id": deleted_id})
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/exams/views/admin/exams_detail.py
+++ b/apps/exams/views/admin/exams_detail.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.exams_delete import AdminExamDeleteResponseSerializer
 from apps.exams.serializers.admin.exams_update import (
     AdminExamUpdateRequestSerializer,
@@ -175,23 +176,17 @@ class AdminExamDetailAPIView(ExamsExceptionMixin, APIView):
     )
     def delete(self, request: Request, exam_id: int) -> Response:
         if exam_id <= 0:
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_EXAM_DELETE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_EXAM_DELETE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             deleted_id = delete_exam(exam_id)
-        except ExamDeleteNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.EXAM_DELETE_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except ExamDeleteConflictError:
-            return Response(
-                {"error_detail": ErrorMessages.EXAM_DELETE_CONFLICT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+        except ExamDeleteNotFoundError as exc:
+            raise ErrorDetailException(ErrorMessages.EXAM_DELETE_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
+        except ExamDeleteConflictError as exc:
+            raise ErrorDetailException(ErrorMessages.EXAM_DELETE_CONFLICT.value, status.HTTP_409_CONFLICT) from exc
 
         serializer = AdminExamDeleteResponseSerializer({"id": deleted_id})
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/exams/views/admin/questions_create.py
+++ b/apps/exams/views/admin/questions_create.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.questions_create import (
     AdminExamQuestionCreateRequestSerializer,
     AdminExamQuestionCreateResponseSerializer,
@@ -96,22 +97,19 @@ class AdminExamQuestionCreateAPIView(ExamsExceptionMixin, APIView):
     def post(self, request: Request, exam_id: int) -> Response:
         serializer = self.serializer_class(data=request.data)
         if not serializer.is_valid():
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_QUESTION_CREATE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_QUESTION_CREATE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             result = create_exam_question(exam_id, serializer.validated_data)
-        except ExamNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.EXAM_ADMIN_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except ExamQuestionLimitError:
-            return Response(
-                {"error_detail": ErrorMessages.QUESTION_CREATE_CONFLICT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+        except ExamNotFoundError as exc:
+            raise ErrorDetailException(ErrorMessages.EXAM_ADMIN_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
+        except ExamQuestionLimitError as exc:
+            raise ErrorDetailException(
+                ErrorMessages.QUESTION_CREATE_CONFLICT.value,
+                status.HTTP_409_CONFLICT,
+            ) from exc
 
         return Response(AdminExamQuestionCreateResponseSerializer(result).data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin/questions_create.py
+++ b/apps/exams/views/admin/questions_create.py
@@ -16,11 +16,7 @@ from apps.exams.serializers.admin.questions_create import (
     AdminExamQuestionCreateResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.questions_create import (
-    ExamNotFoundError,
-    ExamQuestionLimitError,
-    create_exam_question,
-)
+from apps.exams.services.admin.questions_create import create_exam_question
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -102,14 +98,6 @@ class AdminExamQuestionCreateAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            result = create_exam_question(exam_id, serializer.validated_data)
-        except ExamNotFoundError as exc:
-            raise ErrorDetailException(ErrorMessages.EXAM_ADMIN_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
-        except ExamQuestionLimitError as exc:
-            raise ErrorDetailException(
-                ErrorMessages.QUESTION_CREATE_CONFLICT.value,
-                status.HTTP_409_CONFLICT,
-            ) from exc
+        result = create_exam_question(exam_id, serializer.validated_data)
 
         return Response(AdminExamQuestionCreateResponseSerializer(result).data, status=status.HTTP_201_CREATED)

--- a/apps/exams/views/admin/questions_delete.py
+++ b/apps/exams/views/admin/questions_delete.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.questions_delete import (
     AdminExamQuestionDeleteResponseSerializer,
 )
@@ -93,23 +94,20 @@ class AdminExamQuestionDeleteAPIView(ExamsExceptionMixin, APIView):
 
     def delete(self, request: Request, question_id: int) -> Response:
         if question_id <= 0:
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_QUESTION_DELETE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_QUESTION_DELETE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             result = delete_exam_question(question_id)
-        except ExamQuestionDeleteNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.QUESTION_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except ExamQuestionDeleteConflictError:
-            return Response(
-                {"error_detail": ErrorMessages.QUESTION_DELETE_CONFLICT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+        except ExamQuestionDeleteNotFoundError as exc:
+            raise ErrorDetailException(ErrorMessages.QUESTION_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
+        except ExamQuestionDeleteConflictError as exc:
+            raise ErrorDetailException(
+                ErrorMessages.QUESTION_DELETE_CONFLICT.value,
+                status.HTTP_409_CONFLICT,
+            ) from exc
 
         serializer = self.serializer_class(data=result)
         serializer.is_valid(raise_exception=True)

--- a/apps/exams/views/admin/questions_delete.py
+++ b/apps/exams/views/admin/questions_delete.py
@@ -15,11 +15,7 @@ from apps.exams.serializers.admin.questions_delete import (
     AdminExamQuestionDeleteResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.questions_delete import (
-    ExamQuestionDeleteConflictError,
-    ExamQuestionDeleteNotFoundError,
-    delete_exam_question,
-)
+from apps.exams.services.admin.questions_delete import delete_exam_question
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -99,15 +95,7 @@ class AdminExamQuestionDeleteAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            result = delete_exam_question(question_id)
-        except ExamQuestionDeleteNotFoundError as exc:
-            raise ErrorDetailException(ErrorMessages.QUESTION_NOT_FOUND.value, status.HTTP_404_NOT_FOUND) from exc
-        except ExamQuestionDeleteConflictError as exc:
-            raise ErrorDetailException(
-                ErrorMessages.QUESTION_DELETE_CONFLICT.value,
-                status.HTTP_409_CONFLICT,
-            ) from exc
+        result = delete_exam_question(question_id)
 
         serializer = self.serializer_class(data=result)
         serializer.is_valid(raise_exception=True)

--- a/apps/exams/views/admin/submissions_delete.py
+++ b/apps/exams/views/admin/submissions_delete.py
@@ -15,11 +15,7 @@ from apps.exams.serializers.admin.submissions_delete import (
     AdminExamSubmissionDeleteResponseSerializer,
 )
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
-from apps.exams.services.admin.submissions_delete import (
-    ExamSubmissionDeleteConflictError,
-    ExamSubmissionDeleteNotFoundError,
-    delete_exam_submission,
-)
+from apps.exams.services.admin.submissions_delete import delete_exam_submission
 from apps.exams.views.mixins import ExamsExceptionMixin
 
 
@@ -99,18 +95,7 @@ class AdminExamSubmissionDeleteAPIView(ExamsExceptionMixin, APIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            result = delete_exam_submission(submission_id)
-        except ExamSubmissionDeleteNotFoundError as exc:
-            raise ErrorDetailException(
-                ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value,
-                status.HTTP_404_NOT_FOUND,
-            ) from exc
-        except ExamSubmissionDeleteConflictError as exc:
-            raise ErrorDetailException(
-                ErrorMessages.SUBMISSION_DELETE_CONFLICT.value,
-                status.HTTP_409_CONFLICT,
-            ) from exc
+        result = delete_exam_submission(submission_id)
 
         serializer = self.serializer_class(data=result)
         serializer.is_valid(raise_exception=True)

--- a/apps/exams/views/admin/submissions_delete.py
+++ b/apps/exams/views/admin/submissions_delete.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.admin.submissions_delete import (
     AdminExamSubmissionDeleteResponseSerializer,
 )
@@ -93,23 +94,23 @@ class AdminExamSubmissionDeleteAPIView(ExamsExceptionMixin, APIView):
 
     def delete(self, request: Request, submission_id: int) -> Response:
         if submission_id <= 0:
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_SUBMISSION_DELETE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_SUBMISSION_DELETE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         try:
             result = delete_exam_submission(submission_id)
-        except ExamSubmissionDeleteNotFoundError:
-            return Response(
-                {"error_detail": ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except ExamSubmissionDeleteConflictError:
-            return Response(
-                {"error_detail": ErrorMessages.SUBMISSION_DELETE_CONFLICT.value},
-                status=status.HTTP_409_CONFLICT,
-            )
+        except ExamSubmissionDeleteNotFoundError as exc:
+            raise ErrorDetailException(
+                ErrorMessages.SUBMISSION_DELETE_NOT_FOUND.value,
+                status.HTTP_404_NOT_FOUND,
+            ) from exc
+        except ExamSubmissionDeleteConflictError as exc:
+            raise ErrorDetailException(
+                ErrorMessages.SUBMISSION_DELETE_CONFLICT.value,
+                status.HTTP_409_CONFLICT,
+            ) from exc
 
         serializer = self.serializer_class(data=result)
         serializer.is_valid(raise_exception=True)

--- a/apps/exams/views/admin/submissions_list.py
+++ b/apps/exams/views/admin/submissions_list.py
@@ -14,6 +14,7 @@ from rest_framework.views import APIView
 from apps.core.utils.pagination import SimplePagePagination
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.models import ExamSubmission
 from apps.exams.serializers.admin.submissions_list import (
     AdminExamSubmissionListResponseSerializer,
@@ -110,22 +111,22 @@ class AdminExamSubmissionListAPIView(ExamsExceptionMixin, APIView):
             try:
                 cohort_id_int = int(cohort_id)
                 queryset = queryset.filter(deployment__cohort_id=cohort_id_int)
-            except ValueError:
-                return Response(
-                    {"error_detail": ErrorMessages.INVALID_SUBMISSION_LIST_REQUEST.value},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+            except ValueError as exc:
+                raise ErrorDetailException(
+                    ErrorMessages.INVALID_SUBMISSION_LIST_REQUEST.value,
+                    status.HTTP_400_BAD_REQUEST,
+                ) from exc
 
         # 필터링: 시험 ID
         if exam_id:
             try:
                 exam_id_int = int(exam_id)
                 queryset = queryset.filter(deployment__exam_id=exam_id_int)
-            except ValueError:
-                return Response(
-                    {"error_detail": ErrorMessages.INVALID_SUBMISSION_LIST_REQUEST.value},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+            except ValueError as exc:
+                raise ErrorDetailException(
+                    ErrorMessages.INVALID_SUBMISSION_LIST_REQUEST.value,
+                    status.HTTP_400_BAD_REQUEST,
+                ) from exc
 
         # 정렬
         valid_sort_fields = ["score", "started_at"]
@@ -141,9 +142,9 @@ class AdminExamSubmissionListAPIView(ExamsExceptionMixin, APIView):
 
         # 결과가 비어있을 경우 404 반환
         if not queryset.exists():
-            return Response(
-                {"error_detail": ErrorMessages.SUBMISSION_LIST_NOT_FOUND.value},
-                status=status.HTTP_404_NOT_FOUND,
+            raise ErrorDetailException(
+                ErrorMessages.SUBMISSION_LIST_NOT_FOUND.value,
+                status.HTTP_404_NOT_FOUND,
             )
 
         # 페이지네이션

--- a/apps/exams/views/student/deployments_cheating.py
+++ b/apps/exams/views/student/deployments_cheating.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStudentRole
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.serializers.student.deployments_cheating import (
     ExamCheatingRequestSerializer,
@@ -91,7 +92,7 @@ class ExamCheatingUpdateAPIView(ExamsExceptionMixin, APIView):
         request_serializer.is_valid(raise_exception=True)
         user_id = user.id
         if user_id is None:
-            return Response({"error_detail": ErrorMessages.UNAUTHORIZED.value}, status=status.HTTP_401_UNAUTHORIZED)
+            raise ErrorDetailException(ErrorMessages.UNAUTHORIZED.value, status.HTTP_401_UNAUTHORIZED)
 
         result = update_cheating_count(
             deployment=deployment,

--- a/apps/exams/views/student/deployments_check_code.py
+++ b/apps/exams/views/student/deployments_check_code.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.exams.constants import ErrorMessages
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers import CheckCodeRequestSerializer
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.services.student.deployments_status import (
@@ -99,17 +100,17 @@ class CheckCodeAPIView(ExamsExceptionMixin, APIView):
 
         # 참가 코드 검증
         if deployment.access_code != serializer.validated_data["code"]:
-            return Response(
-                {"error_detail": ErrorMessages.INVALID_CHECK_CODE_REQUEST.value},
-                status=status.HTTP_400_BAD_REQUEST,
+            raise ErrorDetailException(
+                ErrorMessages.INVALID_CHECK_CODE_REQUEST.value,
+                status.HTTP_400_BAD_REQUEST,
             )
 
         # 권한 확인 (수강생만)
         user = cast(User, request.user)
         if user.role != User.Role.STUDENT:
-            return Response(
-                {"error_detail": ErrorMessages.NO_EXAM_TAKE_PERMISSION.value},
-                status=status.HTTP_403_FORBIDDEN,
+            raise ErrorDetailException(
+                ErrorMessages.NO_EXAM_TAKE_PERMISSION.value,
+                status.HTTP_403_FORBIDDEN,
             )
 
         validate_deployment_active(deployment, now=timezone.now())

--- a/apps/exams/views/student/deployments_status.py
+++ b/apps/exams/views/student/deployments_status.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStudentRole
 from apps.exams.constants import ErrorMessages, ExamStatus
+from apps.exams.exceptions import ErrorDetailException
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.serializers.student.deployments_status import (
     ExamStatusResponseSerializer,
@@ -68,7 +69,7 @@ class ExamStatusCheckAPIView(ExamsExceptionMixin, APIView):
 
         user_id = request.user.id
         if user_id is None:
-            return Response({"error_detail": ErrorMessages.UNAUTHORIZED.value}, status=status.HTTP_401_UNAUTHORIZED)
+            raise ErrorDetailException(ErrorMessages.UNAUTHORIZED.value, status.HTTP_401_UNAUTHORIZED)
 
         auto_submitted = auto_submit_if_overdue(deployment=deployment, user_id=user_id).submitted
         exam_status = ExamStatus.CLOSED if auto_submitted else get_exam_status(deployment)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: exams admin/student 뷰의 에러 응답을 ErrorDetailException 기준으로 통일하고, 도메인 예외는 서비스에서 직접 발생하도록 정리했습니다.

## 📄 상세 내용
- [x] admin deployments/questions/submissions 뷰에서 직접 Response 반환 제거
- [x] student deployments_cheating/status/check_code의 401/403 처리 통일
- [x] serializer.errors는 기존 응답 형태 유지
- [x] admin 서비스에서 ErrorDetailException 직접 raise하도록 통일
- [x] admin 뷰의 도메인 예외 try/except 제거 및 import 정리
- [x] deployments_status 인자명 충돌 수정(status → status_value)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
변경 파일:
- apps/exams/services/admin/deployments_create.py
- apps/exams/services/admin/deployments_detail.py
- apps/exams/services/admin/deployments_status.py
- apps/exams/services/admin/exams_create.py
- apps/exams/services/admin/exams_delete.py
- apps/exams/services/admin/questions_create.py
- apps/exams/services/admin/questions_delete.py
- apps/exams/services/admin/submissions_delete.py
- apps/exams/views/admin/deployments_create.py
- apps/exams/views/admin/deployments_detail.py
- apps/exams/views/admin/deployments_status.py
- apps/exams/views/admin/exams_create.py
- apps/exams/views/admin/exams_detail.py
- apps/exams/views/admin/questions_create.py
- apps/exams/views/admin/questions_delete.py
- apps/exams/views/admin/submissions_delete.py
- apps/exams/views/admin/submissions_list.py
- apps/exams/views/student/deployments_cheating.py
- apps/exams/views/student/deployments_check_code.py
- apps/exams/views/student/deployments_status.py

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).