### PR TITLE
[refactor/qna/FE_request/extent_schema_correction] refactor: 프론트 요청-오기입된 request 필드명 examples로 인한 스웨거 사용시 혼선 교정

### DIFF
--- a/apps/qna/docs/api_request_examples.py
+++ b/apps/qna/docs/api_request_examples.py
@@ -17,12 +17,14 @@ class QueryParameterExamples:
             "answer_status": "answered",
             "sort": "latest",
         },
+        request_only=True,
     )
 
     # --- Admin ---
     ADMIN_CATEGORY_LIST = OpenApiExample(
         name="어드민 카테고리 목록 조회 query parameter 예시",
         value={"page": 1, "size": 20, "search_keyword": "Django", "category_type": "small"},
+        request_only=True,
     )
 
     ADMIN_QUESTION_LIST = OpenApiExample(
@@ -35,6 +37,7 @@ class QueryParameterExamples:
             "answer_status": "Y",
             "sort": "latest",
         },
+        request_only=True,
     )
 
 
@@ -47,19 +50,21 @@ class RequestBodyExamples:
     QUESTION_CREATE = OpenApiExample(
         name="질문 등록 request body 예시",
         value={
-            "title": "Django에서 ForeignKey 역참조는 어떻게 하나요?",
-            "content": "Django 모델에서 related_name을 지정했을 때 역참조 하는 방법이 궁금합니다.",
+            "title": "새 질문 제목",
+            "content": "새 질문 내용",
             "category_id": 1,
         },
+        request_only=True,
     )
 
     QUESTION_UPDATE = OpenApiExample(
         name="질문 수정 request body 예시",
         value={
-            "title": "Django ORM 역참조 사용 방법 정리",
-            "content": "ForeignKey의 related_name을 지정하면 역참조가 가능합니다.\n\n예시 코드:\n```python\npost.comment_set.all()\n```",
+            "title": "질문 제목 수정",
+            "content": "질문 수정하기\n\n예시 내용 수정:\n```python\npost.comment_set.all()\n```",
             "category_id": 1,
         },
+        request_only=True,
     )
 
     # --- Answers ---
@@ -69,6 +74,7 @@ class RequestBodyExamples:
             "content": "Django ORM 역참조는 `related_name`을 사용하여 접근할 수 있습니다.\n\n```python\npost.comment_set.all()\n```",
             "image_urls": ["https://cdn.ozcodingschool.com/qna/answer_img_1001.png"],
         },
+        request_only=True,
     )
 
     ANSWER_UPDATE = OpenApiExample(
@@ -77,18 +83,24 @@ class RequestBodyExamples:
             "content": "Django ORM에서 `related_name`을 설정하면 역참조가 가능합니다.\n\n예시:\n```python\npost.comment_set.all()\n```",
             "image_urls": ["https://cdn.ozcodingschool.com/qna/answer_img_1001.png"],
         },
+        request_only=True,
     )
 
     ANSWER_COMMENT_CREATE = OpenApiExample(
-        name="답변 댓글 등록 request body 예시", value={"content": "관련 예제 코드도 공유해주실 수 있나요?"}
+        name="답변 댓글 등록 request body 예시",
+        value={"content": "관련 예제 코드도 공유해주실 수 있나요?"},
+        request_only=True,
     )
 
     PRESIGNED_URL = OpenApiExample(
-        name="Presigned URL 발급 request body 예시", value={"file_name": "error_screenshot.png"}
+        name="Presigned URL 발급 request body 예시",
+        value={"file_name": "error_screenshot.png"},
+        request_only=True,
     )
 
     # --- admin ---
     ADMIN_CATEGORY_CREATE = OpenApiExample(
         name="어드민 카테고리 등록 request body 예시",
         value={"category_type": "large", "name": "백엔드", "parent_id": None},
+        request_only=True,
     )

--- a/apps/qna/docs/api_request_examples.py
+++ b/apps/qna/docs/api_request_examples.py
@@ -49,7 +49,7 @@ class RequestBodyExamples:
         value={
             "title": "Django에서 ForeignKey 역참조는 어떻게 하나요?",
             "content": "Django 모델에서 related_name을 지정했을 때 역참조 하는 방법이 궁금합니다.",
-            "category": 32,
+            "category_id": 1,
         },
     )
 
@@ -58,7 +58,7 @@ class RequestBodyExamples:
         value={
             "title": "Django ORM 역참조 사용 방법 정리",
             "content": "ForeignKey의 related_name을 지정하면 역참조가 가능합니다.\n\n예시 코드:\n```python\npost.comment_set.all()\n```",
-            "category": 32,
+            "category_id": 1,
         },
     )
 

--- a/apps/qna/docs/api_response_examples.py
+++ b/apps/qna/docs/api_response_examples.py
@@ -12,6 +12,7 @@ class SuccessResponseExamples:
     QUESTION_CREATE = OpenApiExample(
         name="질문 등록 성공 response body 예시",
         value={"message": "질문이 성공적으로 등록되었습니다.", "question_id": 10501},
+        response_only=True,
     )
 
     QUESTION_LIST = OpenApiExample(
@@ -38,6 +39,7 @@ class SuccessResponseExamples:
                 }
             ],
         },
+        response_only=True,
     )
 
     QUESTION_CATEGORY_LIST = OpenApiExample(
@@ -69,6 +71,7 @@ class SuccessResponseExamples:
                 },
             ]
         },
+        response_only=True,
     )
 
     QUESTION_DETAIL = OpenApiExample(
@@ -100,24 +103,32 @@ class SuccessResponseExamples:
                 }
             ],
         },
+        response_only=True,
     )
 
     QUESTION_UPDATE = OpenApiExample(
-        name="질문 수정 성공 response body 예시", value={"question_id": 10501, "updated_at": "2025-03-02 14:14:22"}
+        name="질문 수정 성공 response body 예시",
+        value={"question_id": 10501, "updated_at": "2025-03-02 14:14:22"},
+        response_only=True,
     )
 
     # --- Answers ---
     ANSWER_CREATE = OpenApiExample(
         name="답변 등록 성공 response body 예시",
         value={"answer_id": 801, "question_id": 10501, "author_id": 211, "created_at": "2025-03-02 11:43:20"},
+        response_only=True,
     )
 
     ANSWER_UPDATE = OpenApiExample(
-        name="답변 수정 성공 response body 예시", value={"answer_id": 801, "updated_at": "2025-03-02 15:22:41"}
+        name="답변 수정 성공 response body 예시",
+        value={"answer_id": 801, "updated_at": "2025-03-02 15:22:41"},
+        response_only=True,
     )
 
     ANSWER_ADOPT = OpenApiExample(
-        name="답변 채택 성공 response body 예시", value={"question_id": 10501, "answer_id": 801, "is_adopted": True}
+        name="답변 채택 성공 response body 예시",
+        value={"question_id": 10501, "answer_id": 801, "is_adopted": True},
+        response_only=True,
     )
 
     AI_ANSWER_GENERATE = OpenApiExample(
@@ -129,11 +140,13 @@ class SuccessResponseExamples:
             "using_model": "gemini-2.5-pro",
             "created_at": "2025-03-01 14:20:33",
         },
+        response_only=True,
     )
 
     ANSWER_COMMENT_CREATE = OpenApiExample(
         name="답변 댓글 등록 성공 response body 예시",
         value={"comment_id": 91001, "answer_id": 801, "author_id": 211, "created_at": "2025-03-02 16:30:18"},
+        response_only=True,
     )
 
     PRESIGNED_URL = OpenApiExample(
@@ -143,6 +156,7 @@ class SuccessResponseExamples:
             "img_url": "https://my-bucket.s3.ap-northeast-2.amazonaws.com/uploads/images/questions/uuid.png",
             "key": "uploads/images/questions/uuid.png",
         },
+        response_only=True,
     )
 
     # --- Admin ---
@@ -155,6 +169,7 @@ class SuccessResponseExamples:
             "parent_id": 12,
             "created_at": "2025-03-03 14:11:22",
         },
+        response_only=True,
     )
 
     ADMIN_CATEGORY_LIST = OpenApiExample(
@@ -184,6 +199,7 @@ class SuccessResponseExamples:
                 },
             ],
         },
+        response_only=True,
     )
 
     ADMIN_QUESTION_LIST = OpenApiExample(
@@ -206,6 +222,7 @@ class SuccessResponseExamples:
                 }
             ],
         },
+        response_only=True,
     )
 
     ADMIN_QUESTION_DETAIL = OpenApiExample(
@@ -240,15 +257,19 @@ class SuccessResponseExamples:
                 }
             ],
         },
+        response_only=True,
     )
 
     ADMIN_QUESTION_DELETE = OpenApiExample(
         name="어드민 질의응답 삭제 성공 response body 예시",
         value={"question_id": 10501, "deleted_answer_count": 12, "deleted_comment_count": 45},
+        response_only=True,
     )
 
     ADMIN_ANSWER_DELETE = OpenApiExample(
-        name="어드민 답변 삭제 성공 response body 예시", value={"answer_id": 801, "deleted_comment_count": 9}
+        name="어드민 답변 삭제 성공 response body 예시",
+        value={"answer_id": 801, "deleted_comment_count": 9},
+        response_only=True,
     )
 
 
@@ -261,262 +282,320 @@ class ErrorResponseExamples:
     QUESTION_CREATE_400 = OpenApiExample(
         name="질문 등록 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_QUESTION_CREATE.value},
+        response_only=True,
     )
     QUESTION_CREATE_401 = OpenApiExample(
         name="질문 등록 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_QUESTION_CREATE.value},
+        response_only=True,
     )
     QUESTION_CREATE_403 = OpenApiExample(
         name="질문 등록 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_QUESTION_CREATE.value},
+        response_only=True,
     )
 
     # --- QUESTION_LIST ---
     QUESTION_LIST_400 = OpenApiExample(
         name="질문 목록 조회 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_QUESTION_LIST.value},
+        response_only=True,
     )
     QUESTION_LIST_404 = OpenApiExample(
         name="질문 목록 조회 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_QUESTION_LIST.value},
+        response_only=True,
     )
     #  ---QUESTION_CATEGORY_LIST ---
     QUESTION_CATEGORY_LIST_400 = OpenApiExample(
         name="카테고리 목록 조회 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_QUESTION_CATEGORY_LIST.value},
+        response_only=True,
     )
     # --- QUESTION_DETAIL ---
     QUESTION_DETAIL_400 = OpenApiExample(
         name="질문 상세 조회 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_QUESTION_DETAIL.value},
+        response_only=True,
     )
     QUESTION_DETAIL_404 = OpenApiExample(
         name="질문 상세 조회 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_QUESTION.value},
+        response_only=True,
     )
 
     # --- QUESTION_UPDATE ---
     QUESTION_UPDATE_400 = OpenApiExample(
         name="질문 수정 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_QUESTION_UPDATE.value},
+        response_only=True,
     )
     QUESTION_UPDATE_401 = OpenApiExample(
         name="질문 수정 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_QUESTION_UPDATE.value},
+        response_only=True,
     )
     QUESTION_UPDATE_403 = OpenApiExample(
         name="질문 수정 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_QUESTION_UPDATE.value},
+        response_only=True,
     )
     QUESTION_UPDATE_404 = OpenApiExample(
         name="질문 수정 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_QUESTION.value},
+        response_only=True,
     )
 
     # --- ANSWER_CREATE ---
     ANSWER_CREATE_400 = OpenApiExample(
         name="답변 등록 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ANSWER_CREATE.value},
+        response_only=True,
     )
     ANSWER_CREATE_401 = OpenApiExample(
         name="답변 등록 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ANSWER_CREATE.value},
+        response_only=True,
     )
     ANSWER_CREATE_403 = OpenApiExample(
         name="답변 등록 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ANSWER_CREATE.value},
+        response_only=True,
     )
     ANSWER_CREATE_404 = OpenApiExample(
         name="답변 등록 실패 response body 예시 - 질문 찾을 수 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_QUESTION.value},
+        response_only=True,
     )
 
     # --- ANSWER_UPDATE ---
     ANSWER_UPDATE_400 = OpenApiExample(
         name="답변 수정 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ANSWER_UPDATE.value},
+        response_only=True,
     )
     ANSWER_UPDATE_401 = OpenApiExample(
         name="답변 수정 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ANSWER_UPDATE.value},
+        response_only=True,
     )
     ANSWER_UPDATE_403 = OpenApiExample(
         name="답변 수정 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ANSWER_UPDATE.value},
+        response_only=True,
     )
     ANSWER_UPDATE_404 = OpenApiExample(
         name="답변 수정 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_ANSWER.value},
+        response_only=True,
     )
 
     # --- ANSWER_ADOPT ---
     ANSWER_ADOPT_400 = OpenApiExample(
         name="답변 채택 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ANSWER_ADOPT.value},
+        response_only=True,
     )
     ANSWER_ADOPT_401 = OpenApiExample(
         name="답변 채택 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ANSWER_ADOPT.value},
+        response_only=True,
     )
     ANSWER_ADOPT_403 = OpenApiExample(
         name="답변 채택 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ANSWER_ADOPT.value},
+        response_only=True,
     )
     ANSWER_ADOPT_404 = OpenApiExample(
         name="답변 채택 실패 response body 예시 - 리소스 찾을 수 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_QUESTION_OR_ANSWER.value},
+        response_only=True,
     )
     ANSWER_ADOPT_409 = OpenApiExample(
         name="답변 채택 실패 response body 예시 - 이미 채택됨",
         value={"error_detail": ErrorMessages.CONFLICT_ANSWER_ADOPT.value},
+        response_only=True,
     )
 
     # --- AI_ANSWER_GENERATE ---
     AI_ANSWER_GENERATE_400 = OpenApiExample(
         name="AI 답변 생성 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_AI_REQUEST.value},
+        response_only=True,
     )
     AI_ANSWER_GENERATE_401 = OpenApiExample(
         name="AI 답변 생성 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_AI_REQUEST.value},
+        response_only=True,
     )
     AI_ANSWER_GENERATE_403 = OpenApiExample(
         name="AI 답변 생성 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_AI_REQUEST.value},
+        response_only=True,
     )
     AI_ANSWER_GENERATE_404 = OpenApiExample(
         name="AI 답변 생성 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_AI_QUESTION.value},
+        response_only=True,
     )
     AI_ANSWER_GENERATE_409 = OpenApiExample(
         name="AI 답변 생성 실패 response body 예시 - 이미 생성됨",
         value={"error_detail": ErrorMessages.ALREADY_EXISTS_AI_ANSWER.value},
+        response_only=True,
     )
 
     # --- ANSWER_COMMENT_CREATE ---
     ANSWER_COMMENT_CREATE_400 = OpenApiExample(
         name="답변 댓글 등록 실패 response body 예시 - 글자 수 초과",
         value={"error_detail": ErrorMessages.INVALID_COMMENT_LENGTH.value},
+        response_only=True,
     )
     ANSWER_COMMENT_CREATE_401 = OpenApiExample(
         name="답변 댓글 등록 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_COMMENT_CREATE.value},
+        response_only=True,
     )
     ANSWER_COMMENT_CREATE_403 = OpenApiExample(
         name="답변 댓글 등록 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_COMMENT_CREATE.value},
+        response_only=True,
     )
     ANSWER_COMMENT_CREATE_404 = OpenApiExample(
         name="답변 댓글 등록 실패 response body 예시 - 답변 찾을 수 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_ANSWER.value},
+        response_only=True,
     )
 
     # --- PRESIGNED_URL ---
     PRESIGNED_URL_400 = OpenApiExample(
         name="Presigned URL 발급 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.UNSUPPORTED_FILE_FORMAT.value},
+        response_only=True,
     )
 
     # --- ADMIN_CATEGORY_CREATE ---
     ADMIN_CATEGORY_CREATE_400 = OpenApiExample(
         name="어드민 카테고리 등록 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ADMIN_CATEGORY_CREATE.value},
+        response_only=True,
     )
     ADMIN_CATEGORY_CREATE_401 = OpenApiExample(
         name="어드민 카테고리 등록 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ADMIN_CATEGORY_CREATE.value},
+        response_only=True,
     )
     ADMIN_CATEGORY_CREATE_403 = OpenApiExample(
         name="어드민 카테고리 등록 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ADMIN_CATEGORY_CREATE.value},
+        response_only=True,
     )
     ADMIN_CATEGORY_CREATE_404 = OpenApiExample(
         name="어드민 카테고리 등록 실패 response body 예시 - 부모 미존재",
         value={"error_detail": ErrorMessages.NOT_FOUND_ADMIN_CATEGORY_PARENT.value},
+        response_only=True,
     )
     ADMIN_CATEGORY_CREATE_409 = OpenApiExample(
         name="어드민 카테고리 등록 실패 response body 예시 - 이름 중복",
         value={"error_detail": ErrorMessages.ALREADY_EXISTS_ADMIN_CATEGORY_NAME.value},
+        response_only=True,
     )
 
     # --- ADMIN_CATEGORY_LIST ---
     ADMIN_CATEGORY_LIST_400 = OpenApiExample(
         name="어드민 카테고리 목록 조회 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ADMIN_CATEGORY_LIST.value},
+        response_only=True,
     )
     ADMIN_CATEGORY_LIST_401 = OpenApiExample(
         name="어드민 카테고리 목록 조회 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ADMIN_CATEGORY_LIST.value},
+        response_only=True,
     )
     ADMIN_CATEGORY_LIST_403 = OpenApiExample(
         name="어드민 카테고리 목록 조회 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ADMIN_CATEGORY_LIST.value},
+        response_only=True,
     )
 
     # --- ADMIN_QUESTION_LIST ---
     ADMIN_QUESTION_LIST_400 = OpenApiExample(
         name="어드민 질의응답 목록 조회 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ADMIN_QUESTION_LIST.value},
+        response_only=True,
     )
     ADMIN_QUESTION_LIST_401 = OpenApiExample(
         name="어드민 질의응답 목록 조회 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ADMIN_QUESTION_LIST.value},
+        response_only=True,
     )
     ADMIN_QUESTION_LIST_403 = OpenApiExample(
         name="어드민 질의응답 목록 조회 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ADMIN_QUESTION_LIST.value},
+        response_only=True,
     )
 
     # --- ADMIN_QUESTION_DETAIL ---
     ADMIN_QUESTION_DETAIL_400 = OpenApiExample(
         name="어드민 질의응답 상세 조회 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ADMIN_QUESTION_DETAIL.value},
+        response_only=True,
     )
     ADMIN_QUESTION_DETAIL_401 = OpenApiExample(
         name="어드민 질의응답 상세 조회 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ADMIN_QUESTION_DETAIL.value},
+        response_only=True,
     )
     ADMIN_QUESTION_DETAIL_403 = OpenApiExample(
         name="어드민 질의응답 상세 조회 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ADMIN_QUESTION_DETAIL.value},
+        response_only=True,
     )
     ADMIN_QUESTION_DETAIL_404 = OpenApiExample(
         name="어드민 질의응답 상세 조회 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_QUESTION.value},
+        response_only=True,
     )
 
     # --- ADMIN_QUESTION_DELETE ---
     ADMIN_QUESTION_DELETE_400 = OpenApiExample(
         name="어드민 질의응답 삭제 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ADMIN_QUESTION_DELETE.value},
+        response_only=True,
     )
     ADMIN_QUESTION_DELETE_401 = OpenApiExample(
         name="어드민 질의응답 삭제 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ADMIN_QUESTION_DELETE.value},
+        response_only=True,
     )
     ADMIN_QUESTION_DELETE_403 = OpenApiExample(
         name="어드민 질의응답 삭제 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ADMIN_QUESTION_DELETE.value},
+        response_only=True,
     )
     ADMIN_QUESTION_DELETE_404 = OpenApiExample(
         name="어드민 질의응답 삭제 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_ADMIN_QUESTION.value},
+        response_only=True,
     )
 
     # --- ADMIN_ANSWER_DELETE ---
     ADMIN_ANSWER_DELETE_400 = OpenApiExample(
         name="어드민 답변 삭제 실패 response body 예시 - 잘못된 요청",
         value={"error_detail": ErrorMessages.INVALID_ADMIN_ANSWER_DELETE.value},
+        response_only=True,
     )
     ADMIN_ANSWER_DELETE_401 = OpenApiExample(
         name="어드민 답변 삭제 실패 response body 예시 - 인증 실패",
         value={"error_detail": ErrorMessages.UNAUTHORIZED_ADMIN_ANSWER_DELETE.value},
+        response_only=True,
     )
     ADMIN_ANSWER_DELETE_403 = OpenApiExample(
         name="어드민 답변 삭제 실패 response body 예시 - 권한 없음",
         value={"error_detail": ErrorMessages.FORBIDDEN_ADMIN_ANSWER_DELETE.value},
+        response_only=True,
     )
     ADMIN_ANSWER_DELETE_404 = OpenApiExample(
         name="어드민 답변 삭제 실패 response body 예시 - 데이터 없음",
         value={"error_detail": ErrorMessages.NOT_FOUND_ADMIN_ANSWER.value},
+        response_only=True,
     )

--- a/apps/qna/serializers/answer/request.py
+++ b/apps/qna/serializers/answer/request.py
@@ -13,7 +13,7 @@ class AnswerCreateSerializer(serializers.ModelSerializer[Answer]):
     답변 등록 시리얼라이저
     """
 
-    content = serializers.CharField(required=True, help_text="답변 내용 (마크다운)")
+    content = serializers.CharField(required=True, help_text="답변 내용")
     image_urls = serializers.ListField(
         child=serializers.URLField(), required=False, allow_empty=True, default=list, help_text="첨부 이미지 URL 목록"
     )

--- a/apps/qna/serializers/question/request.py
+++ b/apps/qna/serializers/question/request.py
@@ -16,18 +16,14 @@ class QuestionCreateSerializer(serializers.ModelSerializer[Question]):
     질문 등록 시리얼라이저
     """
 
+    title = serializers.CharField(required=True, help_text="질문 제목")
+    content = serializers.CharField(required=True, help_text="질문 내용")
     category_id = serializers.IntegerField(required=True, help_text="카테고리 ID (소분류)")
     default_error_message = ErrorMessages.INVALID_QUESTION_CREATE
 
     class Meta:
         model = Question
         fields = ["title", "content", "category_id"]
-
-    def validate_category_id(self, value: int) -> int:
-        """카테고리 FK 존재 여부 검증"""
-        if not QuestionCategory.objects.filter(id=value).exists():
-            raise QnaBaseException(detail=ErrorMessages.NOT_FOUND_CATEGORY, status_code=status.HTTP_400_BAD_REQUEST)
-        return value
 
 
 # ==============================================================================

--- a/apps/qna/services/question/command.py
+++ b/apps/qna/services/question/command.py
@@ -1,7 +1,10 @@
 from typing import Any
 
 from django.db import transaction
+from rest_framework import status
 
+from apps.qna.constants import ErrorMessages
+from apps.qna.exceptions import QnaBaseException
 from apps.qna.models import Question, QuestionCategory
 from apps.qna.utils.model_types import User
 
@@ -25,7 +28,13 @@ class QuestionCommandService:
             Question: 생성된 질문 객체
 
         """
+
         category_id = data.pop("category_id")
-        category = QuestionCategory.objects.get(id=category_id)
+
+        try:
+            category = QuestionCategory.objects.get(id=category_id)
+        except QuestionCategory.DoesNotExist:
+            raise QnaBaseException(detail=ErrorMessages.NOT_FOUND_CATEGORY, status_code=status.HTTP_404_NOT_FOUND)
+
         question = Question.objects.create(author=author, category=category, **data)
         return question

--- a/apps/qna/services/question/query.py
+++ b/apps/qna/services/question/query.py
@@ -46,7 +46,7 @@ class QuestionQueryService:
         if not category_id:
             return queryset
 
-        # [Guard Clause] DB에 존재하지 않는 카테고리일 경우만 404 발생
+        # DB에 존재하지 않는 카테고리일 경우만 404 발생
         if not QuestionCategory.objects.filter(id=category_id).exists():
             raise QnaBaseException(detail=ErrorMessages.NOT_FOUND_QUESTION, status_code=status.HTTP_404_NOT_FOUND)
 
@@ -62,7 +62,7 @@ class QuestionQueryService:
     def _apply_status_filter(queryset: QuerySet[Question], answer_status: str | None) -> QuerySet[Question]:
         """답변 상태에 따른 필터링 (성능 최적화 적용)"""
         if answer_status == "waiting":
-            # [Optimization] Count를 구하는 것보다 역참조 존재 여부를 체크하는 것이 훨씬 빠름
+            # Count를 구하는 것보다 역참조 존재 여부를 체크하는 것이 훨씬 빠름
             return queryset.filter(answers__isnull=True)
 
         if answer_status == "answered":
@@ -74,7 +74,7 @@ class QuestionQueryService:
     @staticmethod
     def _apply_sorting(queryset: QuerySet[Question], sort: str) -> QuerySet[Question]:
         """정렬 전략 분리"""
-        # 정렬 시 created_at과 id를 같이 사용하여 페이징 시 정렬 보장(Stable Sort)
+        # 정렬 시 created_at과 id를 같이 사용하여 페이징 시 정렬 보장 (Stable Sort)
         sort_map = {
             "latest": ["-created_at", "-id"],
             "oldest": ["created_at", "id"],

--- a/apps/qna/tests/test_exception_handler.py
+++ b/apps/qna/tests/test_exception_handler.py
@@ -10,9 +10,7 @@ QnA 예외처리 시나리오별 테스트
 """
 
 import json
-import logging
 from typing import Any
-from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
@@ -67,7 +65,7 @@ class CategoryNotFoundExceptionTest(TestCase):
         response = self.client.post(self.url, data=json.dumps(data), content_type="application/json", **auth_header)
         res_data = response.json()
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("error_detail", res_data)
         self.assertEqual(res_data["error_detail"], ErrorMessages.NOT_FOUND_CATEGORY.value)
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: extend_schema의 request body examples에 필드명 오기입 정정

## 📄 상세 내용
- [x] extend_schema의 request body examples에 필드명 오기입 정정
- [x] 스웨서 ui에서 request example이 response example에서 조회되는 문제 수정
- [x] category_id 검증 리팩터링 (시리얼라이저 --> 서비스로 이동)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
