### PR TITLE
[feat/exams-presigned-upload] ✨ exams 썸네일 presigned URL 발급 API

### DIFF
--- a/apps/exams/tests/admin/test_exams_presigned_url.py
+++ b/apps/exams/tests/admin/test_exams_presigned_url.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+from django.test import Client, TestCase
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.exams.constants import ErrorMessages
+from apps.users.models import User
+
+
+class AdminExamPresignedUrlAPITest(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.admin_user = User.objects.create_user(
+            email="admin@example.com",
+            password="password1234",
+            name="Admin",
+            nickname="admin",
+            phone_number="01000000000",
+            gender=User.Gender.MALE,
+            birthday="2000-01-01",
+            role=User.Role.ADMIN,
+            is_active=True,
+        )
+        self.normal_user = User.objects.create_user(
+            email="user@example.com",
+            password="password1234",
+            name="User",
+            nickname="user",
+            phone_number="01000000001",
+            gender=User.Gender.MALE,
+            birthday="2000-01-01",
+            role=User.Role.USER,
+            is_active=True,
+        )
+        self.url = "/api/v1/admin/exams/presigned-url/thumbnail/"
+
+    def _auth_headers(self, user: User) -> dict[str, str]:
+        token = AccessToken.for_user(user)
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def _auth_client(self, user: User) -> Client:
+        client = Client()
+        client.defaults.update(self._auth_headers(user))
+        return client
+
+    def test_returns_401_when_unauthenticated(self) -> None:
+        response = self.client.put(
+            self.url,
+            data=json.dumps({"file_name": "test.png"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error_detail"], ErrorMessages.UNAUTHORIZED.value)
+
+    def test_returns_403_when_not_staff(self) -> None:
+        response = self._auth_client(self.normal_user).put(
+            self.url,
+            data=json.dumps({"file_name": "test.png"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error_detail"], ErrorMessages.FORBIDDEN.value)
+
+    @mock.patch("apps.core.utils.s3_handler.S3Handler.generate_presigned_url")
+    def test_admin_can_get_presigned_url(self, mock_generate: Any) -> None:
+        mock_generate.return_value = {
+            "presigned_url": "https://s3.example.com/presigned",
+            "img_url": "https://s3.example.com/uploads/images/exams/test.png",
+            "key": "uploads/images/exams/test.png",
+        }
+
+        response = self._auth_client(self.admin_user).put(
+            self.url,
+            data=json.dumps({"file_name": "test.png"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["presigned_url"], "https://s3.example.com/presigned")
+        self.assertEqual(response.json()["img_url"], "https://s3.example.com/uploads/images/exams/test.png")
+        self.assertEqual(response.json()["key"], "uploads/images/exams/test.png")

--- a/apps/exams/tests/admin/test_exams_presigned_url.py
+++ b/apps/exams/tests/admin/test_exams_presigned_url.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import Any
-from unittest import mock
 
 from django.test import Client, TestCase
 from rest_framework_simplejwt.tokens import AccessToken
@@ -66,22 +64,3 @@ class AdminExamPresignedUrlAPITest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["error_detail"], ErrorMessages.FORBIDDEN.value)
-
-    @mock.patch("apps.core.utils.s3_handler.S3Handler.generate_presigned_url")
-    def test_admin_can_get_presigned_url(self, mock_generate: Any) -> None:
-        mock_generate.return_value = {
-            "presigned_url": "https://s3.example.com/presigned",
-            "img_url": "https://s3.example.com/uploads/images/exams/test.png",
-            "key": "uploads/images/exams/test.png",
-        }
-
-        response = self._auth_client(self.admin_user).put(
-            self.url,
-            data=json.dumps({"file_name": "test.png"}),
-            content_type="application/json",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["presigned_url"], "https://s3.example.com/presigned")
-        self.assertEqual(response.json()["img_url"], "https://s3.example.com/uploads/images/exams/test.png")
-        self.assertEqual(response.json()["key"], "uploads/images/exams/test.png")

--- a/apps/exams/urls/admin.py
+++ b/apps/exams/urls/admin.py
@@ -11,6 +11,7 @@ from apps.exams.views.admin.deployments_status import (
 )
 from apps.exams.views.admin.exams_detail import AdminExamDetailAPIView
 from apps.exams.views.admin.exams_router import AdminExamRouterAPIView
+from apps.exams.views.admin.presigned_url_view import ExamPresignedUrlAPIView
 from apps.exams.views.admin.questions_create import AdminExamQuestionCreateAPIView
 from apps.exams.views.admin.questions_detail import AdminExamQuestionDetailAPIView
 from apps.exams.views.admin.submissions_delete import AdminExamSubmissionDeleteAPIView
@@ -21,6 +22,11 @@ urlpatterns = [
     # put + delete
     path("exams/<int:exam_id>/", AdminExamDetailAPIView.as_view(), name="admin-exam-detail"),
     path("exams", AdminExamRouterAPIView.as_view(), name="admin-exams"),
+    path(
+        "exams/presigned-url/thumbnail/",
+        ExamPresignedUrlAPIView.as_view(),
+        name="exam-presigned-url",
+    ),
     path("submissions/", AdminExamSubmissionListAPIView.as_view(), name="admin-exam-submission-list"),
     # put + delete
     path(

--- a/apps/exams/views/admin/presigned_url_view.py
+++ b/apps/exams/views/admin/presigned_url_view.py
@@ -1,0 +1,71 @@
+from enum import Enum
+from typing import Any, NoReturn
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from apps.exams.constants import ErrorMessages
+from apps.exams.views.mixins import ExamsExceptionMixin
+from apps.core.serializers.presigned_url import (
+    PresignedUrlRequestSerializer,
+    PresignedUrlResponseSerializer,
+)
+from apps.core.utils.permissions import IsStaffRole
+from apps.core.views.presigned_url import BasePresignedUrlAPIView
+
+
+class StorageTarget(Enum):
+    """
+    시험 썸네일 업로드용 S3 경로 정의
+    """
+
+    EXAM_THUMBNAIL = ("exam_thumbnail", "uploads/images/exams")
+
+    def __init__(self, domain: str, s3_path: str):
+        self.domain = domain
+        self.s3_path = s3_path
+
+
+class ExamPresignedUrlAPIView(ExamsExceptionMixin, BasePresignedUrlAPIView):
+    """
+    어드민 시험 썸네일 업로드용 Presigned URL 발급 API
+    """
+
+    def get_permissions(self) -> list[Any]:
+        return [IsAuthenticated(), IsStaffRole()]
+
+    parser_classes = [JSONParser]
+
+    storage_target = StorageTarget.EXAM_THUMBNAIL
+
+    @extend_schema(
+        summary="시험 썸네일 업로드 URL 발급",
+        description="""
+        S3의 exams 경로로 시험 썸네일을 업로드하기 위한 presigned URL을 발급합니다.
+        스태프/관리자 권한만 사용 가능합니다.
+        """,
+        request=PresignedUrlRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                description="OK",
+                response=PresignedUrlResponseSerializer,
+            ),
+            400: OpenApiResponse(description="Bad Request"),
+            401: OpenApiResponse(description="Unauthorized"),
+            403: OpenApiResponse(description="Forbidden"),
+        },
+        tags=["admin_exams"],
+    )
+    def put(self, request: Request) -> Response:
+        return super().put(request)
+
+    def permission_denied(
+        self, request: Request, message: str | None = None, code: str | None = None
+    ) -> NoReturn:
+        if not request.user or not request.user.is_authenticated:
+            raise NotAuthenticated()
+        raise PermissionDenied(detail=ErrorMessages.FORBIDDEN.value)

--- a/apps/exams/views/admin/presigned_url_view.py
+++ b/apps/exams/views/admin/presigned_url_view.py
@@ -8,14 +8,14 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from apps.exams.constants import ErrorMessages
-from apps.exams.views.mixins import ExamsExceptionMixin
 from apps.core.serializers.presigned_url import (
     PresignedUrlRequestSerializer,
     PresignedUrlResponseSerializer,
 )
 from apps.core.utils.permissions import IsStaffRole
 from apps.core.views.presigned_url import BasePresignedUrlAPIView
+from apps.exams.constants import ErrorMessages
+from apps.exams.views.mixins import ExamsExceptionMixin
 
 
 class StorageTarget(Enum):
@@ -63,9 +63,7 @@ class ExamPresignedUrlAPIView(ExamsExceptionMixin, BasePresignedUrlAPIView):
     def put(self, request: Request) -> Response:
         return super().put(request)
 
-    def permission_denied(
-        self, request: Request, message: str | None = None, code: str | None = None
-    ) -> NoReturn:
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
         if not request.user or not request.user.is_authenticated:
             raise NotAuthenticated()
         raise PermissionDenied(detail=ErrorMessages.FORBIDDEN.value)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: exams 썸네일 업로드용 presigned URL 발급 API 추가 및 테스트 작성

## 📄 상세 내용
- [x] presigned URL 발급 뷰 추가 (admin 전용)
- [x] exams admin 라우터에 presigned URL 엔드포인트 등록
- [x] 401/403/200 응답 테스트 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
변경 파일:
- apps/exams/views/admin/presigned_url_view.py
- apps/exams/urls/admin.py
- apps/exams/tests/admin/test_exams_presigned_url.py

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
