### PR TITLE
[feature/posts-like-create] 게시글 좋아요 등록 및 취소 API

### DIFF
--- a/apps/posts/constants/post_const.py
+++ b/apps/posts/constants/post_const.py
@@ -31,3 +31,12 @@ class PostSuccessMessage:
     POST_CREATE_SUCCESS = "게시글이 성공적으로 등록되었습니다."
     POST_UPDATE_SUCCESS = "게시글이 성공적으로 수정되었습니다."
     POST_DELETE_SUCCESS = "게시글이 삭제되었습니다."
+
+
+class PostLikeMessage:
+    """
+    게시글 좋아요 관련 성공 및 에러 메시지 상수
+    """
+
+    LIKE_REGISTER = "좋아요가 등록되었습니다."
+    LIKE_CANCEL = "좋아요가 취소되었습니다."

--- a/apps/posts/services/post_like_service.py
+++ b/apps/posts/services/post_like_service.py
@@ -1,0 +1,34 @@
+from django.db import transaction
+
+from apps.posts.exceptions.post_exceptions import PostNotFoundException
+from apps.posts.models.post import Post
+from apps.posts.models.post_likes import PostLike
+from apps.users.models.user import User
+
+
+class PostLikeService:
+    """
+    게시글 좋아요 관련 비즈니스 로직을 처리하는 서비스 클래스
+    """
+
+    @staticmethod
+    @transaction.atomic
+    def register_like(user: User, post_id: int) -> PostLike:
+        """
+        좋아요 등록: 멱등성을 보장하며 is_liked를 True로 설정합니다.
+        """
+        try:
+            post = Post.objects.get(id=post_id)
+        except Post.DoesNotExist:
+            raise PostNotFoundException()
+
+        like, _ = PostLike.objects.update_or_create(user=user, post=post, defaults={"is_liked": True})
+        return like
+
+    @staticmethod
+    @transaction.atomic
+    def cancel_like(user: User, post_id: int) -> None:
+        """
+        좋아요 취소: 해당 유저의 좋아요 상태를 False로 업데이트합니다.
+        """
+        PostLike.objects.filter(user=user, post_id=post_id).update(is_liked=False)

--- a/apps/posts/tests/test_post_like.py
+++ b/apps/posts/tests/test_post_like.py
@@ -1,0 +1,109 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.posts.constants.post_const import PostLikeMessage
+from apps.posts.models.post import Post
+from apps.posts.models.post_category import PostCategory
+from apps.posts.models.post_likes import PostLike
+from apps.users.models.user import User
+
+
+class PostLikeAPITest(APITestCase):
+    """
+    게시글 좋아요 등록(POST) 및 취소(DELETE) API 기능을 검증하는 테스트 클래스입니다.
+    """
+
+    def setUp(self) -> None:
+        """
+        테스트에 필요한 초기 데이터를 생성합니다.
+        """
+        self.user = User.objects.create_user(
+            email="test_user@test.com",
+            password="Password1234!",
+            nickname="테스터",
+            name="홍길동",
+            phone_number="01012345678",
+            gender="M",
+            birthday="1995-01-01",
+        )
+        self.category = PostCategory.objects.create(name="커뮤니티")
+        self.post = Post.objects.create(
+            author=self.user,
+            category=self.category,
+            title="좋아요 테스트용 게시글",
+            content="본문 내용",
+        )
+        # URL 설정: posts:post-like-registration (명세에 따른 name)
+        self.url = reverse("posts:post-like", kwargs={"post_id": self.post.id})
+
+        # 유저 인증 처리
+        self.client.force_authenticate(user=self.user)
+
+    def test_post_like_registration_success_status_201(self) -> None:
+        """
+        [POST] 좋아요 등록 성공 시 상태 코드 201과 명세된 메시지 및 데이터를 반환하는지 검증합니다.
+        """
+        # API 호출
+        response = self.client.post(self.url)
+
+        # 1. 상태 코드 201 검증
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # 2. 응답 데이터 메시지 검증 (상수 활용)
+        self.assertEqual(response.data["detail"], PostLikeMessage.LIKE_REGISTER)
+
+        # 3. 데이터베이스 상태 검증
+        like_exists = PostLike.objects.filter(user=self.user, post=self.post, is_liked=True).exists()
+        self.assertTrue(like_exists)
+
+    def test_post_like_idempotency_check(self) -> None:
+        """
+        [POST] 이미 좋아요를 누른 상태에서 다시 등록 요청 시, 중복 생성되지 않고 201을 유지하는지 검증합니다.
+        """
+        # 첫 번째 등록
+        self.client.post(self.url)
+
+        # 두 번째 등록 (중복 요청)
+        response = self.client.post(self.url)
+
+        # 멱등성 검증: 에러가 발생하지 않고 성공 응답 유지
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PostLike.objects.filter(user=self.user, post=self.post).count(), 1)
+        self.assertTrue(PostLike.objects.get(user=self.user, post=self.post).is_liked)
+
+    def test_post_like_cancel_success_status_200(self) -> None:
+        """
+        [DELETE] 좋아요 취소 성공 시 상태 코드 200과 취소 메시지를 반환하는지 검증합니다.
+        """
+        # 먼저 좋아요 데이터가 있는 상태를 만듦
+        PostLike.objects.create(user=self.user, post=self.post, is_liked=True)
+
+        # API 호출 (DELETE 메서드)
+        response = self.client.delete(self.url)
+
+        # 1. 상태 코드 200 검증
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # 2. 메시지 검증
+        self.assertEqual(response.data["detail"], PostLikeMessage.LIKE_CANCEL)
+
+        # 3. 데이터베이스 필드 변경 검증 (물리 삭제가 아닌 상태값 변경)
+        like = PostLike.objects.get(user=self.user, post=self.post)
+        self.assertFalse(like.is_liked)
+
+    def test_post_like_unauthorized_user_status_401(self) -> None:
+        """
+        인증되지 않은 유저가 접근 시 상태 코드 401을 반환하는지 검증합니다.
+        """
+        self.client.logout()
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_post_like_not_found_status_404(self) -> None:
+        """
+        존재하지 않는 게시글에 대해 좋아요 요청 시 상태 코드 404를 반환하는지 검증합니다.
+        """
+        invalid_url = reverse("posts:post-like", kwargs={"post_id": 9999})
+        response = self.client.post(invalid_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/apps/posts/urls.py
+++ b/apps/posts/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from apps.posts.views.category_views import CategoryListView
+from apps.posts.views.post_like_views import PostLikeAPIView
 from apps.posts.views.post_views import PostDetailView, PostListCreateView
 
 app_name = "posts"
@@ -9,4 +10,5 @@ urlpatterns = [
     path("", PostListCreateView.as_view(), name="post-list-create"),
     path("<int:post_id>", PostDetailView.as_view(), name="post-detail"),
     path("categories", CategoryListView.as_view(), name="category-list"),
+    path("<int:post_id>/like/", PostLikeAPIView.as_view(), name="post-like"),
 ]

--- a/apps/posts/views/post_like_views.py
+++ b/apps/posts/views/post_like_views.py
@@ -1,0 +1,55 @@
+from typing import cast
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.posts.constants.post_const import PostLikeMessage
+from apps.posts.services.post_like_service import PostLikeService
+from apps.users.models import User
+
+
+class PostLikeAPIView(APIView):
+    """
+    게시글 좋아요 관련 API
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["posts"],
+        summary="게시글 좋아요 등록",
+        description="인증된 사용자가 특정 게시글에 좋아요를 등록합니다.",
+        responses={
+            201: OpenApiResponse(description=PostLikeMessage.LIKE_REGISTER),
+            400: OpenApiResponse(description="잘못된 요청"),
+            401: OpenApiResponse(description="인증 자격 증명이 유효하지 않음"),
+            404: OpenApiResponse(description="게시글을 찾을 수 없음"),
+        },
+    )
+    def post(self, request: Request, post_id: int) -> Response:
+        """게시글 좋아요 등록 (POST)"""
+        user = cast(User, request.user)
+        PostLikeService.register_like(user=user, post_id=post_id)
+
+        return Response({"detail": PostLikeMessage.LIKE_REGISTER}, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        tags=["posts"],
+        summary="게시글 좋아요 취소",
+        description="인증된 사용자가 특정 게시글의 좋아요를 취소합니다.",
+        responses={
+            200: OpenApiResponse(description=PostLikeMessage.LIKE_CANCEL),
+            401: OpenApiResponse(description="인증 자격 증명이 유효하지 않음"),
+            404: OpenApiResponse(description="게시글을 찾을 수 없음"),
+        },
+    )
+    def delete(self, request: Request, post_id: int) -> Response:
+        """게시글 좋아요 취소 (DELETE)"""
+        user = cast(User, request.user)
+        PostLikeService.cancel_like(user=user, post_id=post_id)
+
+        return Response({"detail": PostLikeMessage.LIKE_CANCEL}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 게시글 좋아요 등록 및 취소 API

## 📄 상세 내용
브랜치명은 좋아요 등록이지만 실제로 좋아요 등록 및 취소 API 함께 올립니다.

## 📸 스크린샷 (선택)
<img width="361" height="166" alt="스크린샷 2026-02-05 오후 6 36 20" src="https://github.com/user-attachments/assets/5d43689b-212c-4968-a2e2-aeec7497e786" />
<img width="374" height="161" alt="스크린샷 2026-02-05 오후 6 36 38" src="https://github.com/user-attachments/assets/a6507f50-90b7-4fec-9ce9-dc8e4c64d762" />


## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
