### PR TITLE
[fix/exams-submit-answer-type] 🐛 제출 답안 type 표기 매핑 지원

### DIFF
--- a/apps/exams/serializers/student/submissions_create.py
+++ b/apps/exams/serializers/student/submissions_create.py
@@ -12,6 +12,18 @@ class ExamAnswerSerializer(serializers.Serializer[Any]):
     type = serializers.ChoiceField(choices=ExamQuestion.TypeChoices.choices)
     submitted_answer = serializers.JSONField()  # 답의 자료형이 제각각이라 JSONField
 
+    def validate_type(self, value: str) -> str:
+        type_map = {
+            "multiple_choice": ExamQuestion.TypeChoices.MULTI_SELECT,
+            "single_choice": ExamQuestion.TypeChoices.SINGLE_CHOICE,
+            "fill_blank": ExamQuestion.TypeChoices.FILL_IN_BLANK,
+            "ordering": ExamQuestion.TypeChoices.ORDERING,
+            "short_answer": ExamQuestion.TypeChoices.SHORT_ANSWER,
+            "ox": ExamQuestion.TypeChoices.OX,
+        }
+
+        return type_map.get(value, value)
+
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         if attrs["type"] == ExamQuestion.TypeChoices.SHORT_ANSWER:
             submitted_answer = attrs.get("submitted_answer")


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 제출 API에서 answers[].type의 API 표기값을 내부 enum으로 매핑해 400 오류를 해결했습니다.

## 📄 상세 내용
- [x] answers[].type에 multiple_choice/single_choice/fill_blank/ordering/short_answer/ox 매핑 추가
- [x] 내부 enum으로 변환 후 기존 검증 유지

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
변경 파일:
- apps/exams/serializers/student/submissions_create.py

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
