### PR TITLE
[fix/exams-single-choice-response] 단일선다 응시 조회 옵션 노출 보정

### DIFF
--- a/apps/exams/services/student/deployments_take.py
+++ b/apps/exams/services/student/deployments_take.py
@@ -98,7 +98,11 @@ def build_take_exam_response(*, result: TakeExamResult) -> dict[str, Any]:
                 "point": question_data.get("point", 0),
                 "prompt": question_data.get("prompt"),
                 "blank_count": question_data.get("blank_count") if question_type == "fill_blank" else None,
-                "options": question_data.get("options") if question_type in ["multiple_choice", "ordering"] else None,
+                "options": (
+                    question_data.get("options")
+                    if question_type in ["multiple_choice", "ordering", "single_choice"]
+                    else None
+                ),
                 "answer_input": None,
             }
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: single_choice 문제 조회 응답에 options 누락 보정

## 📄 상세 내용
- [x] 단일선다를 선택형으로 처리하여 options 반환
- [x] 응시 문제 조회 응답 스키마와 일치하도록 보정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
변경 파일:
- `apps/exams/services/student/deployments_take.py`

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
