### PR TITLE
[refactor/exams-layer-separation] ♻️ refactor: exams 목록 조회 파라미터 검증/예외 처리 분리

### DIFF
--- a/apps/exams/services/student/deployments_list.py
+++ b/apps/exams/services/student/deployments_list.py
@@ -25,7 +25,6 @@ from apps.exams.constants import ErrorMessages
 from apps.exams.error_map import raise_error
 from apps.exams.models.exam_deployments import ExamDeployment
 from apps.exams.models.exam_submissions import ExamSubmission
-from apps.exams.serializers.student.deployments_list import ExamListQuerySerializer
 
 
 @dataclass(frozen=True)
@@ -110,6 +109,7 @@ class ExamDeploymentListService:
     # 코호트 조회 + status 파라미터 검증을 한 번에 수행.
     @staticmethod
     def _validate_request(user_id: int, params: dict[str, str]) -> ExamListParams:
+        allowed_status = {"all", "done", "pending"}
         cohort_id = (
             CohortStudent.objects.filter(user_id=user_id)
             .order_by("created_at")
@@ -119,14 +119,14 @@ class ExamDeploymentListService:
         if cohort_id is None:
             raise_error(ErrorMessages.USER_NOT_FOUND)
 
-        query_serializer = ExamListQuerySerializer(data=params)
-        if not query_serializer.is_valid():
+        status = params.get("status") or "all"
+        if status not in allowed_status:
             raise_error(ErrorMessages.INVALID_EXAM_LIST_REQUEST, status_override=404)
 
         return ExamListParams(
             user_id=user_id,
             cohort_id=int(cohort_id),
-            status=str(query_serializer.validated_data["status"]),
+            status=status,
         )
 
     # 검증된 파라미터로 학생 시험 목록 조회용 QuerySet 구성.

--- a/apps/exams/views/admin/deployments_list.py
+++ b/apps/exams/views/admin/deployments_list.py
@@ -8,7 +8,6 @@ from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
 )
-from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -18,7 +17,7 @@ from rest_framework.views import APIView
 from apps.core.utils.pagination import SimplePagePagination
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
-from apps.exams.exceptions import ErrorDetailException
+from apps.exams.error_map import raise_error
 from apps.exams.serializers.admin.deployments_list import (
     AdminExamDeploymentListItemSerializer,
 )
@@ -102,7 +101,7 @@ class AdminExamDeploymentListAPIView(ExamsExceptionMixin, APIView):
                 order=qp.get("order"),
             )
         except InvalidAdminDeploymentListParams as exc:
-            raise ErrorDetailException(str(exc), status.HTTP_400_BAD_REQUEST) from exc
+            raise_error(ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST)
 
         queryset = AdminDeploymentListService.get_queryset(params)
 

--- a/apps/exams/views/admin/exams_list.py
+++ b/apps/exams/views/admin/exams_list.py
@@ -1,7 +1,6 @@
 from typing import NoReturn
 
 from django.db.models import QuerySet
-from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -9,7 +8,7 @@ from rest_framework.request import Request
 from apps.core.utils.pagination import AdminExamPagination
 from apps.core.utils.permissions import IsStaffRole
 from apps.exams.constants import ErrorMessages
-from apps.exams.exceptions import ErrorDetailException
+from apps.exams.error_map import raise_error
 from apps.exams.models import Exam
 from apps.exams.serializers.admin.exams_list import AdminExamListItemSerializer
 from apps.exams.services.admin.exams_list import (
@@ -47,5 +46,5 @@ class AdminExamListView(ExamsExceptionMixin, ListAPIView[Exam]):
                 order=qp.get("order"),
             )
         except InvalidAdminExamListParams as exc:
-            raise ErrorDetailException(str(exc), status.HTTP_400_BAD_REQUEST) from exc
+            raise_error(ErrorMessages.INVALID_EXAM_LIST_REQUEST)
         return AdminExamListService.get_queryset(params)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: exams 목록 조회 파라미터 검증/예외 처리 분리

## 📄 상세 내용
- [x] apps/exams/views/admin/exams_list.py: 파라미터 오류 처리에서 ErrorDetailException 제거 → raise_error(ErrorMessages.INVALID_EXAM_LIST_REQUEST)로 통일
- [x] apps/exams/views/admin/deployments_list.py: 파라미터 오류 처리에서 ErrorDetailException 제거 → raise_error(ErrorMessages.INVALID_DEPLOYMENT_LIST_REQUEST)로 통일
- [x] apps/exams/services/student/deployments_list.py: 서비스에서 serializer 의존 제거, status 검증을 단순 로직으로 처리 (allowed: all/done/pending)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
