### PR TITLE
[Feature/exam submit] 쪽지시험 제출 serializer 수정

### DIFF
--- a/apps/exams/serializers/student/submissions_create.py
+++ b/apps/exams/serializers/student/submissions_create.py
@@ -9,7 +9,7 @@ from apps.exams.models import ExamQuestion
 class ExamAnswerSerializer(serializers.Serializer[Any]):
     # 개별 문제 답안 구조를 정의, 검증
     question_id = serializers.IntegerField()
-    type = serializers.ChoiceField(choices=ExamQuestion.TypeChoices.choices)
+    type = serializers.CharField()
     submitted_answer = serializers.JSONField()  # 답의 자료형이 제각각이라 JSONField
 
     def validate_type(self, value: str) -> str:
@@ -22,7 +22,16 @@ class ExamAnswerSerializer(serializers.Serializer[Any]):
             "ox": ExamQuestion.TypeChoices.OX,
         }
 
-        return type_map.get(value, value)
+        mapped = type_map.get(value)
+
+        # 모델에 있는 값인지 검증
+        valid_internal_types = {
+            choice for choice, _ in ExamQuestion.TypeChoices.choices
+        }
+        if mapped not in valid_internal_types:
+            raise serializers.ValidationError(ErrorMessages.INVALID_EXAM_SESSION.value)
+
+        return mapped
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         if attrs["type"] == ExamQuestion.TypeChoices.SHORT_ANSWER:

--- a/apps/exams/serializers/student/submissions_create.py
+++ b/apps/exams/serializers/student/submissions_create.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework import serializers
 
 from apps.exams.constants import ErrorMessages
+from apps.exams.error_map import raise_error
 from apps.exams.models import ExamQuestion
 
 
@@ -22,12 +23,10 @@ class ExamAnswerSerializer(serializers.Serializer[Any]):
             "ox": ExamQuestion.TypeChoices.OX,
         }
 
-        mapped = type_map.get(value)
+        mapped = type_map.get(value.lower())
 
         # 모델에 있는 값인지 검증
-        valid_internal_types = {
-            choice for choice, _ in ExamQuestion.TypeChoices.choices
-        }
+        valid_internal_types = {choice for choice, _ in ExamQuestion.TypeChoices.choices}
         if mapped not in valid_internal_types:
             raise serializers.ValidationError(ErrorMessages.INVALID_EXAM_SESSION.value)
 
@@ -49,7 +48,13 @@ class ExamSubmissionCreateSerializer(serializers.Serializer[Any]):
     deployment_id = serializers.IntegerField()
     started_at = serializers.DateTimeField()
     cheating_count = serializers.IntegerField(default=0)
-    answers = ExamAnswerSerializer(many=True, allow_empty=False)  # 아예 하나도 안푼것에 대한 방지
+    answers = ExamAnswerSerializer(many=True)
+
+    # answer이 비었을 때
+    def validate_answers(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not value:
+            raise_error(ErrorMessages.INVALID_EXAM_SESSION)
+        return value
 
 
 class ExamSubmissionCreateResponseSerializer(serializers.Serializer[Any]):

--- a/apps/exams/serializers/student/submissions_create.py
+++ b/apps/exams/serializers/student/submissions_create.py
@@ -25,6 +25,9 @@ class ExamAnswerSerializer(serializers.Serializer[Any]):
 
         mapped = type_map.get(value.lower())
 
+        if mapped is None:
+            raise serializers.ValidationError(ErrorMessages.INVALID_EXAM_SESSION.value)
+
         # 모델에 있는 값인지 검증
         valid_internal_types = {choice for choice, _ in ExamQuestion.TypeChoices.choices}
         if mapped not in valid_internal_types:

--- a/apps/exams/services/student/submissions_create.py
+++ b/apps/exams/services/student/submissions_create.py
@@ -2,29 +2,13 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from django.db import transaction
-from rest_framework import status
-from rest_framework.exceptions import APIException
 
 from apps.exams.constants import ErrorMessages
+from apps.exams.error_map import raise_error
 from apps.exams.models import ExamSubmission
-from apps.exams.serializers import ErrorResponseSerializer
 from apps.exams.services.answers_json import normalize_answers_json
 from apps.exams.services.student.deployments_status import is_deployment_time_closed
 from apps.users.models import User
-
-
-class InvalidSubmissionError(APIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-
-    def __init__(self, message: str = ErrorMessages.INVALID_EXAM_SESSION.value) -> None:
-        self.detail: Dict[str, Any] = ErrorResponseSerializer({"error_detail": message}).data
-
-
-class AlreadySubmittedError(APIException):
-    status_code = status.HTTP_409_CONFLICT
-
-    def __init__(self, message: str = ErrorMessages.SUBMISSION_ALREADY_SUBMITTED.value) -> None:
-        self.detail: Dict[str, Any] = ErrorResponseSerializer({"error_detail": message}).data
 
 
 @transaction.atomic
@@ -48,15 +32,21 @@ def submit_exam(
             deployment_id=deployment_id,
         )
     except ExamSubmission.DoesNotExist:
-        raise InvalidSubmissionError()
-
-    # 시험 마감 후 제출
-    if is_deployment_time_closed(submission.deployment):
-        raise InvalidSubmissionError()
+        raise_error(ErrorMessages.INVALID_EXAM_SESSION)
 
     # 이미 제출됨
     if submission.answers_json:
-        raise AlreadySubmittedError()
+        raise_error(ErrorMessages.SUBMISSION_ALREADY_SUBMITTED)
+
+    # 응시 중에 시험 시간이 끝나면 푼 답안까지만 저장 (자동제출)
+    if is_deployment_time_closed(submission.deployment):
+        # 남은 문제 제외하고 제출된 것만 저장
+        # answers에는 실제 제출한 문제만 담겨 있으므로 그대로 사용
+        submission.answers_json = normalize_answers_json(answers)
+        submission.started_at = started_at
+        submission.cheating_count = cheating_count
+        submission.save(update_fields=["answers_json", "started_at", "cheating_count", "updated_at"])
+        return submission
 
     # 답안 저장
     submission.answers_json = normalize_answers_json(answers)

--- a/apps/exams/services/student/submissions_create.py
+++ b/apps/exams/services/student/submissions_create.py
@@ -2,9 +2,8 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from django.db import transaction
-from django.utils import timezone
 from rest_framework import status
-from rest_framework.exceptions import APIException, ErrorDetail
+from rest_framework.exceptions import APIException
 
 from apps.exams.constants import ErrorMessages
 from apps.exams.models import ExamSubmission

--- a/apps/exams/services/student/submissions_create.py
+++ b/apps/exams/services/student/submissions_create.py
@@ -38,16 +38,6 @@ def submit_exam(
     if submission.answers_json:
         raise_error(ErrorMessages.SUBMISSION_ALREADY_SUBMITTED)
 
-    # 응시 중에 시험 시간이 끝나면 푼 답안까지만 저장 (자동제출)
-    if is_deployment_time_closed(submission.deployment):
-        # 남은 문제 제외하고 제출된 것만 저장
-        # answers에는 실제 제출한 문제만 담겨 있으므로 그대로 사용
-        submission.answers_json = normalize_answers_json(answers)
-        submission.started_at = started_at
-        submission.cheating_count = cheating_count
-        submission.save(update_fields=["answers_json", "started_at", "cheating_count", "updated_at"])
-        return submission
-
     # 답안 저장
     submission.answers_json = normalize_answers_json(answers)
     submission.started_at = started_at

--- a/apps/exams/tests/student/test_submissions_create.py
+++ b/apps/exams/tests/student/test_submissions_create.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from apps.courses.models import Cohort, Course, Subject
+from apps.exams.constants import ErrorMessages
 from apps.exams.models import (
     Exam,
     ExamDeployment,
@@ -109,7 +110,7 @@ class ExamSubmissionTest(APITestCase):
         }
 
         response = self.client.post(
-            f"/api/v1/exams/submissions",
+            "/api/v1/exams/submissions",
             data,
             format="json",
         )
@@ -117,3 +118,91 @@ class ExamSubmissionTest(APITestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["score"], 5)
         self.assertEqual(response.data["correct_answer_count"], 1)
+
+    # 잘못된 type으로 제출 시 400 에러
+    def test_submission_exam_invalid_type(self) -> None:
+        data = {
+            "deployment_id": self.deployment.id,
+            "started_at": timezone.now().isoformat(),
+            "cheating_count": 0,
+            "answers": [
+                {
+                    "question_id": self.question.id,
+                    "type": "invalid_type",
+                    "submitted_answer": "O",
+                }
+            ],
+        }
+        response = self.client.post(
+            "/api/v1/exams/submissions",
+            data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(ErrorMessages.INVALID_EXAM_SESSION.value, str(response.data))
+
+    # SHORT_ANSWER인데 문자열이 아닌 경우
+    def test_submission_exam_short_answer_invalid_type(self) -> None:
+        self.question.type = ExamQuestion.TypeChoices.SHORT_ANSWER
+        self.question.save()
+
+        data = {
+            "deployment_id": self.deployment.id,
+            "started_at": timezone.now().isoformat(),
+            "cheating_count": 0,
+            "answers": [
+                {
+                    "question_id": self.question.id,
+                    "type": "short_answer",
+                    "submitted_answer": 123,  # 숫자라서 실패
+                }
+            ],
+        }
+        response = self.client.post(
+            "/api/v1/exams/submissions",
+            data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(ErrorMessages.INVALID_SHORT_ANSWER_TYPE.value, str(response.data))
+
+    # SHORT_ANSWER인데 길이 초과
+    def test_submission_exam_short_answer_too_long(self) -> None:
+        self.question.type = ExamQuestion.TypeChoices.SHORT_ANSWER
+        self.question.save()
+
+        data = {
+            "deployment_id": self.deployment.id,
+            "started_at": timezone.now().isoformat(),
+            "cheating_count": 0,
+            "answers": [
+                {
+                    "question_id": self.question.id,
+                    "type": "short_answer",
+                    "submitted_answer": "a" * 25,  # 20자 초과
+                }
+            ],
+        }
+        response = self.client.post(
+            "/api/v1/exams/submissions",
+            data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(ErrorMessages.INVALID_SHORT_ANSWER_LENGTH.value, str(response.data))
+
+    # answers=[] 제출 시 400 에러
+    def test_submission_exam_empty_answers(self) -> None:
+        data = {
+            "deployment_id": self.deployment.id,
+            "started_at": timezone.now().isoformat(),
+            "cheating_count": 0,
+            "answers": [],
+        }
+        response = self.client.post(
+            "/api/v1/exams/submissions",
+            data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(ErrorMessages.INVALID_EXAM_SESSION.value, str(response.data))

--- a/apps/exams/tests/student/test_submissions_create.py
+++ b/apps/exams/tests/student/test_submissions_create.py
@@ -206,3 +206,32 @@ class ExamSubmissionTest(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(ErrorMessages.INVALID_EXAM_SESSION.value, str(response.data))
+
+    # 시험 시간이 지나면 남은 문제 제외하고 자동 제출
+    def test_submission_exam_time_over_auto_submit(self) -> None:
+        self.deployment.close_at = timezone.now() - timedelta(minutes=1)
+        self.deployment.save()
+
+        data = {
+            "deployment_id": self.deployment.id,
+            "started_at": timezone.now().isoformat(),
+            "cheating_count": 0,
+            "answers": [
+                {
+                    "question_id": self.question.id,
+                    "type": self.question.type,
+                    "submitted_answer": "O",
+                }
+            ],
+        }
+
+        response = self.client.post(
+            "/api/v1/exams/submissions",
+            data,
+            format="json",
+        )
+
+        # 자동 제출이므로 201 반환
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["score"], 5)
+        self.assertEqual(response.data["correct_answer_count"], 1)


### PR DESCRIPTION
 2. 변경 또는 추가사항
- serializer에 타입 필드 수정 및 검증 로직 추가

## ✅ PR 요약
- 작업 요약: 쪽지시험 제출 serializer 수정

## 📄 상세 내용
- [x] apps/exams/serializers/student/submissions_create에 타입 필드 수정 및 검증 로직 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
