### PR TITLE
[feat/exams-force-submit-on-deactivate] 관리자측 배포 비활성화 시 응시 자동 제출

### DIFF
--- a/apps/exams/services/student/auto_submit.py
+++ b/apps/exams/services/student/auto_submit.py
@@ -22,6 +22,7 @@ def auto_submit_if_overdue(
     deployment: ExamDeployment,
     user_id: int,
     now: datetime | None = None,
+    force: bool = False,
 ) -> AutoSubmitResult:
     current = now or timezone.now()
 
@@ -37,9 +38,10 @@ def auto_submit_if_overdue(
     if submission.answers_json:
         return AutoSubmitResult(submitted=False)
 
-    deadline = submission.started_at + timedelta(minutes=deployment.duration_time)
-    if current <= deadline:
-        return AutoSubmitResult(submitted=False)
+    if not force:
+        deadline = submission.started_at + timedelta(minutes=deployment.duration_time)
+        if current <= deadline:
+            return AutoSubmitResult(submitted=False)
 
     answers = normalize_answers_json(submission.answers_json)
     if not answers:

--- a/apps/exams/tests/student/test_status.py
+++ b/apps/exams/tests/student/test_status.py
@@ -94,6 +94,23 @@ class ExamStatusCheckAPITest(TestCase):
         self.deployment.status = ExamDeployment.StatusChoices.DEACTIVATED
         self.deployment.save(update_fields=["status"])
 
+        ExamQuestion.objects.create(
+            exam=self.exam,
+            question="OX 문제",
+            type=ExamQuestion.TypeChoices.OX,
+            answer="O",
+            point=5,
+            explanation="설명",
+        )
+
+        submission = ExamSubmission.objects.create(
+            submitter=self.student,
+            deployment=self.deployment,
+            started_at=timezone.now(),
+            cheating_count=0,
+            answers_json=[],
+        )
+
         response = self.client.get(
             f"/api/v1/exams/deployments/{self.deployment.id}/status",
             headers=self._auth_headers(self.student),
@@ -103,6 +120,10 @@ class ExamStatusCheckAPITest(TestCase):
         data = response.json()
         self.assertEqual(data["exam_status"], "closed")
         self.assertTrue(data["force_submit"])
+
+        submission.refresh_from_db()
+        self.assertEqual(len(submission.answers_json), 1)
+        self.assertIsNone(submission.answers_json[0].get("submitted_answer"))
 
     def test_status_returns_403_for_non_student(self) -> None:
         response = self.client.get(

--- a/apps/exams/views/student/deployments_status.py
+++ b/apps/exams/views/student/deployments_status.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 from apps.core.utils.permissions import IsStudentRole
 from apps.exams.constants import ErrorMessages, ExamStatus
 from apps.exams.error_map import raise_error
+from apps.exams.models import ExamDeployment
 from apps.exams.serializers.error_serializers import ErrorResponseSerializer
 from apps.exams.serializers.student.deployments_status import (
     ExamStatusResponseSerializer,
@@ -70,7 +71,8 @@ class ExamStatusCheckAPIView(ExamsExceptionMixin, APIView):
         if user_id is None:
             raise_error(ErrorMessages.UNAUTHORIZED)
 
-        auto_submitted = auto_submit_if_overdue(deployment=deployment, user_id=user_id).submitted
+        force_by_admin = deployment.status != ExamDeployment.StatusChoices.ACTIVATED
+        auto_submitted = auto_submit_if_overdue(deployment=deployment, user_id=user_id, force=force_by_admin).submitted
         exam_status = ExamStatus.CLOSED if auto_submitted else get_exam_status(deployment)
         is_closed = exam_status == ExamStatus.CLOSED
         serializer = self.serializer_class(


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 관리자 비활성화 시 응시 세션 자동 제출 로직 추가

## 📄 상세 내용
- [x] auto_submit 서비스에 강제 제출 옵션 추가
- [x] 상태 체크 API에서 비활성화 시 자동 제출 트리거
- [x] 비활성화 시 제출 생성 검증 테스트 보강

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- `apps/exams/services/student/auto_submit.py`
- `apps/exams/views/student/deployments_status.py`
- `apps/exams/tests/student/test_status.py`

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
