### PR TITLE
[fix/admin-exam-list-response-schema] 어드민 시험 목록 응답 스키마 정합성 수정

### DIFF
--- a/apps/exams/serializers/admin/exams_list.py
+++ b/apps/exams/serializers/admin/exams_list.py
@@ -4,10 +4,7 @@ from apps.exams.models import Exam
 
 
 class AdminExamListItemSerializer(serializers.ModelSerializer[Exam]):
-    exam_id = serializers.IntegerField(source="id", read_only=True)
-    exam_title = serializers.CharField(source="title", read_only=True)
-
-    subject_name = serializers.CharField(source="subject.name", read_only=True)
+    subject_name = serializers.CharField(source="subject.title", read_only=True)
     question_count = serializers.IntegerField(read_only=True)
     submit_count = serializers.IntegerField(read_only=True)
 
@@ -16,8 +13,8 @@ class AdminExamListItemSerializer(serializers.ModelSerializer[Exam]):
     class Meta:
         model = Exam
         fields = [
-            "exam_id",
-            "exam_title",
+            "id",
+            "title",
             "subject_name",
             "question_count",
             "submit_count",

--- a/apps/exams/tests/admin/test_exams_list.py
+++ b/apps/exams/tests/admin/test_exams_list.py
@@ -126,6 +126,8 @@ class AdminExamListAPITest(TestCase):
 
         self.assertEqual(data["total_count"], 3)
         self.assertEqual(len(data["exams"]), 3)
+        for exam in data["exams"]:
+            self.assertIn("subject_name", exam)
 
     def test_200_success_and_title_asc_sort(self) -> None:
         client = self._auth_client(self.admin_user)
@@ -149,7 +151,7 @@ class AdminExamListAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
 
-        titles = [e["exam_title"] for e in data["exams"]]
+        titles = [e["title"] for e in data["exams"]]
         self.assertEqual(titles, ["aaa", "bbb", "ccc"])
 
     def test_200_filter_by_subject(self) -> None:
@@ -179,7 +181,7 @@ class AdminExamListAPITest(TestCase):
         data = response.json()
 
         self.assertEqual(data["total_count"], 1)
-        self.assertEqual(data["exams"][0]["exam_title"], "bbb")
+        self.assertEqual(data["exams"][0]["title"], "bbb")
 
     def test_200_question_and_submit_count_calculated_correctly(self) -> None:
         client = self._auth_client(self.admin_user)
@@ -237,12 +239,12 @@ class AdminExamListAPITest(TestCase):
         data = response.json()
         exams = data["exams"]
 
-        exam_aaa = next(e for e in exams if e["exam_title"] == "aaa")
+        exam_aaa = next(e for e in exams if e["title"] == "aaa")
 
         self.assertEqual(exam_aaa["question_count"], 2)
         self.assertEqual(exam_aaa["submit_count"], 1)
 
         for e in exams:
-            if e["exam_title"] != "aaa":
+            if e["title"] != "aaa":
                 self.assertEqual(e["question_count"], 0)
                 self.assertEqual(e["submit_count"], 0)

--- a/apps/exams/views/admin/exams_router.py
+++ b/apps/exams/views/admin/exams_router.py
@@ -48,7 +48,31 @@ class AdminExamRouterAPIView(ExamsExceptionMixin, APIView):
             ),
         ],
         responses={
-            200: OpenApiResponse(description="OK"),
+            200: OpenApiResponse(
+                description="OK",
+                examples=[
+                    OpenApiExample(
+                        "성공",
+                        value={
+                            "page": 1,
+                            "size": 10,
+                            "total_count": 42,
+                            "exams": [
+                                {
+                                    "id": 101,
+                                    "title": "Python 기본 문법 테스트",
+                                    "subject_name": "Python",
+                                    "question_count": 20,
+                                    "submit_count": 65,
+                                    "created_at": "2025-02-01 13:20:33",
+                                    "updated_at": "2025-02-05 15:10:20",
+                                    "detail_url": "/admin/exams/101",
+                                }
+                            ],
+                        },
+                    )
+                ],
+            ),
             400: OpenApiResponse(
                 response=ErrorResponseSerializer,
                 description="Bad Request",


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 시험 목록 응답 스키마를 명세와 일치하도록 수정하고 테스트/문서 예시를 갱신했습니다.

## 📄 상세 내용
- [x] subject_name 참조를 subject.title로 수정
- [x] 시험 목록 응답 필드를 id/title로 변경
- [x] 테스트 및 OpenAPI 응답 예시 업데이트

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 테스트: `python manage.py test apps.exams.tests.admin.test_exams_list`

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)