### PR TITLE
[fix/student-submission-timestamp] 학생 시험 결과 제출시간 매핑 수정

### DIFF
--- a/apps/exams/serializers/student/submissions_result.py
+++ b/apps/exams/serializers/student/submissions_result.py
@@ -17,7 +17,7 @@ class ExamSubmissionSerializer(serializers.ModelSerializer[ExamSubmission]):
     total_score = serializers.IntegerField(source="score", read_only=True)
     elapsed_time = serializers.SerializerMethodField()
 
-    submitted_at = serializers.DateTimeField(source="created_at", read_only=True)
+    submitted_at = serializers.DateTimeField(source="updated_at", read_only=True)
 
     exam = ExamSimpleSerializer(source="deployment.exam", read_only=True)
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 학생 시험 결과 응답의 submitted_at을 제출 시각(업데이트 시각)으로 매핑했습니다.

## 📄 상세 내용
- [x] submitted_at 소스를 created_at → updated_at으로 변경
- [x] 학생 시험 결과 응답의 제출 시각 표시 오류 수정
- [x] 관련 테스트 확인

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 테스트: `python manage.py test apps.exams.tests.student.test_submissions_result`

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).