### PR TITLE
[fix/student-elapsed-time] 시험 결과 elapsed_time 계산 기준 수정

### DIFF
--- a/apps/exams/serializers/student/submissions_result.py
+++ b/apps/exams/serializers/student/submissions_result.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from rest_framework import serializers
 
-from apps.exams.models import Exam, ExamSubmission
+from apps.exams.models import Exam, ExamQuestion, ExamSubmission
 from apps.exams.services.answers_json import normalize_answers_json
 
 
@@ -46,10 +46,6 @@ class ExamSubmissionSerializer(serializers.ModelSerializer[ExamSubmission]):
 
     def _answers_map(self, obj: ExamSubmission) -> dict[int, object]:
         normalized = normalize_answers_json(obj.answers_json)
-        if obj.answers_json != normalized:
-            obj.answers_json = normalized
-            obj.save(update_fields=["answers_json"])
-
         m: dict[int, object] = {}
         for item in normalized:
             qid = item.get("question_id")
@@ -89,7 +85,12 @@ class ExamSubmissionSerializer(serializers.ModelSerializer[ExamSubmission]):
             else:
                 answer_norm = [answer]
 
-            is_correct = sorted(map(str, submitted_norm)) == sorted(map(str, answer_norm))
+            submitted_values = list(map(str, submitted_norm))
+            answer_values = list(map(str, answer_norm))
+            if q.type in {ExamQuestion.TypeChoices.ORDERING, ExamQuestion.TypeChoices.FILL_IN_BLANK}:
+                is_correct = submitted_values == answer_values
+            else:
+                is_correct = sorted(submitted_values) == sorted(answer_values)
 
             options = []
             if q.options_json:

--- a/apps/exams/serializers/student/submissions_result.py
+++ b/apps/exams/serializers/student/submissions_result.py
@@ -41,7 +41,7 @@ class ExamSubmissionSerializer(serializers.ModelSerializer[ExamSubmission]):
         read_only_fields = fields
 
     def get_elapsed_time(self, obj: ExamSubmission) -> int:
-        seconds = (obj.created_at - obj.started_at).total_seconds()
+        seconds = (obj.updated_at - obj.started_at).total_seconds()
         return int(seconds // 60)
 
     def _answers_map(self, obj: ExamSubmission) -> dict[int, object]:

--- a/apps/exams/tests/student/test_submissions_result.py
+++ b/apps/exams/tests/student/test_submissions_result.py
@@ -21,6 +21,7 @@ class ExamResultRetrieveAPITest(TestCase):
     other_user: User
     q1: ExamQuestion
     q2: ExamQuestion
+    q3: ExamQuestion
     submission: ExamSubmission
     url: str
 
@@ -97,8 +98,8 @@ class ExamResultRetrieveAPITest(TestCase):
             options_json='["a","b","c"]',
             explanation="설명",
         )
-        self.q3 = ExamQuestion.objects.create(
-            exam=self.exam,
+        cls.q3 = ExamQuestion.objects.create(
+            exam=cls.exam,
             question="순서 문제",
             type=ExamQuestion.TypeChoices.ORDERING,
             answer=["1", "2", "3"],

--- a/apps/exams/tests/student/test_submissions_result.py
+++ b/apps/exams/tests/student/test_submissions_result.py
@@ -97,6 +97,15 @@ class ExamResultRetrieveAPITest(TestCase):
             options_json='["a","b","c"]',
             explanation="설명",
         )
+        self.q3 = ExamQuestion.objects.create(
+            exam=self.exam,
+            question="순서 문제",
+            type=ExamQuestion.TypeChoices.ORDERING,
+            answer=["1", "2", "3"],
+            point=10,
+            options_json='["1","2","3"]',
+            explanation="설명",
+        )
 
         cls.submission = ExamSubmission.objects.create(
             submitter=cls.student,
@@ -149,3 +158,29 @@ class ExamResultRetrieveAPITest(TestCase):
         self.submission.save(update_fields=["answers_json"])
         res = self.client.get(self.url, HTTP_AUTHORIZATION=self._bearer(self.student))
         self.assertEqual(res.status_code, 400)
+
+    def test_ordering_question_requires_correct_order(self) -> None:
+        self.submission.answers_json = [
+            {"question_id": self.q3.id, "submitted_answer": ["3", "2", "1"]},
+        ]
+        self.submission.save(update_fields=["answers_json"])
+
+        res = self.client.get(self.url, HTTP_AUTHORIZATION=self._bearer(self.student))
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+
+        q3_data = next(q for q in data["questions"] if q["id"] == self.q3.id)
+        self.assertFalse(q3_data["is_correct"])
+
+    def test_ordering_question_accepts_correct_order(self) -> None:
+        self.submission.answers_json = [
+            {"question_id": self.q3.id, "submitted_answer": ["1", "2", "3"]},
+        ]
+        self.submission.save(update_fields=["answers_json"])
+
+        res = self.client.get(self.url, HTTP_AUTHORIZATION=self._bearer(self.student))
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+
+        q3_data = next(q for q in data["questions"] if q["id"] == self.q3.id)
+        self.assertTrue(q3_data["is_correct"])


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 시험 결과 상세 조회의 elapsed_time 계산 기준을 updated_at으로 맞췄습니다.

## 📄 상세 내용
- [x] elapsed_time 계산을 updated_at 기준으로 변경

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 테스트: `python manage.py test apps.exams.tests.student.test_submissions_result`

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
