### PR TITLE
[fix/posts-like] 좋아요 집계 변수명 통일

### DIFF
--- a/apps/posts/selectors/post_selectors.py
+++ b/apps/posts/selectors/post_selectors.py
@@ -57,7 +57,7 @@ class PostSelector:
         """
 
         queryset = Post.objects.select_related("author", "category").annotate(
-            like_count=Count("likes", filter=Q(likes__is_liked=True), distinct=True)
+            likes_count=Count("likes", filter=Q(likes__is_liked=True), distinct=True)
         )
 
         try:

--- a/apps/posts/serializers/post_serializers.py
+++ b/apps/posts/serializers/post_serializers.py
@@ -122,7 +122,7 @@ class PostDetailSerializer(serializers.ModelSerializer[Post]):
 
     author = serializers.SerializerMethodField()
     category = serializers.SerializerMethodField()
-    like_count = serializers.IntegerField()
+    likes_count = serializers.IntegerField()
 
     class Meta:
         model = Post
@@ -133,7 +133,7 @@ class PostDetailSerializer(serializers.ModelSerializer[Post]):
             "category",
             "content",
             "view_count",
-            "like_count",
+            "likes_count",
             "created_at",
             "updated_at",
         ]


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 좋아요 집계 변수명 통일

## 📄 상세 내용
게시글 상세 조회는 like_count, 게시글 목록 조회는 likes_count 반환
일관성을 위해 전부 likes_count로 변경
API 명세는 like_count로 되어 있지만 likes_count가 더 명확한 의미를 가진 것 같아
API 명세와 다른 필드명 적용

## 📸 스크린샷 (선택)
<img width="131" height="25" alt="스크린샷 2026-02-09 오후 4 20 10" src="https://github.com/user-attachments/assets/c01127f2-b202-4302-bbe5-b3934d6aae1e" />
<img width="134" height="30" alt="스크린샷 2026-02-09 오후 4 20 23" src="https://github.com/user-attachments/assets/0ea06b44-2a47-4a43-97bf-f6eab830d733" />


## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
