### PR TITLE
[feat/exams-auto-submit-celery] 시험 강제제출 자동화 태스크 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 media/
 static/
 staticfiles/
+celerybeat-schedule

--- a/apps/exams/tasks.py
+++ b/apps/exams/tasks.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from celery import shared_task  # type: ignore[import-untyped]
+from django.db.models import Q
+from django.utils import timezone
+
+from apps.exams.models import ExamSubmission
+from apps.exams.services.student.auto_submit import auto_submit_if_overdue
+
+
+@shared_task  # type: ignore[misc]
+def auto_submit_overdue_exams() -> int:
+    """마감된 시험 제출을 강제 제출로 처리합니다."""
+    now = timezone.now()
+    queryset = (
+        ExamSubmission.objects.select_related("deployment")
+        .filter(Q(answers_json={}) | Q(answers_json=[]))
+        .only("id", "deployment_id", "submitter_id", "started_at")
+    )
+    processed = 0
+    for submission in queryset.iterator():
+        result = auto_submit_if_overdue(
+            deployment=submission.deployment,
+            user_id=submission.submitter_id,
+            now=now,
+        )
+        if result.submitted:
+            processed += 1
+    return processed

--- a/apps/exams/tasks.py
+++ b/apps/exams/tasks.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 from celery import shared_task  # type: ignore[import-untyped]
-from django.db.models import Q
+from django.db.models import DateTimeField, DurationField, ExpressionWrapper, F, Q
 from django.utils import timezone
 
 from apps.exams.models import ExamSubmission
@@ -12,9 +14,18 @@ from apps.exams.services.student.auto_submit import auto_submit_if_overdue
 def auto_submit_overdue_exams() -> int:
     """마감된 시험 제출을 강제 제출로 처리합니다."""
     now = timezone.now()
+    duration_expr = ExpressionWrapper(
+        F("deployment__duration_time") * timedelta(minutes=1),
+        output_field=DurationField(),
+    )
+    deadline_expr = ExpressionWrapper(
+        F("started_at") + duration_expr,
+        output_field=DateTimeField(),
+    )
     queryset = (
         ExamSubmission.objects.select_related("deployment")
-        .filter(Q(answers_json={}) | Q(answers_json=[]))
+        .annotate(deadline=deadline_expr)
+        .filter(Q(answers_json={}) | Q(answers_json=[]), deadline__lt=now)
         .only("id", "deployment_id", "submitter_id", "started_at")
     )
     processed = 0

--- a/apps/exams/tests/test_auto_submit_task.py
+++ b/apps/exams/tests/test_auto_submit_task.py
@@ -1,0 +1,107 @@
+from datetime import date, datetime, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.courses.models.cohorts import Cohort
+from apps.courses.models.courses import Course
+from apps.courses.models.subjects import Subject
+from apps.exams.models import Exam, ExamDeployment, ExamQuestion, ExamSubmission
+from apps.exams.tasks import auto_submit_overdue_exams
+from apps.users.models import User
+
+
+class AutoSubmitOverdueExamsTaskTest(TestCase):
+    def setUp(self) -> None:
+        self.course = Course.objects.create(
+            name="코스",
+            tag="CS",
+            description="설명",
+            thumbnail_img_url="course.png",
+        )
+        self.subject = Subject.objects.create(
+            course=self.course,
+            title="과목",
+            number_of_days=1,
+            number_of_hours=1,
+            thumbnail_img_url="subject.png",
+        )
+        self.cohort = Cohort.objects.create(
+            course=self.course,
+            number=1,
+            max_student=10,
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=30),
+        )
+        self.exam = Exam.objects.create(
+            subject=self.subject,
+            title="시험",
+            thumbnail_img_url="exam.png",
+        )
+        self.student = User.objects.create_user(
+            email="student@example.com",
+            password="password123",
+            name="학생",
+            nickname="닉네임",
+            phone_number="01012345678",
+            gender=User.Gender.MALE,
+            birthday=date(2000, 1, 1),
+            role=User.Role.STUDENT,
+            is_active=True,
+        )
+
+        ExamQuestion.objects.create(
+            exam=self.exam,
+            question="문제",
+            type=ExamQuestion.TypeChoices.SINGLE_CHOICE,
+            answer="A",
+            point=5,
+            options_json='["A","B"]',
+            explanation="설명",
+        )
+
+    def _create_submission(self, *, started_at: datetime, duration_minutes: int) -> ExamSubmission:
+        deployment = ExamDeployment.objects.create(
+            cohort=self.cohort,
+            exam=self.exam,
+            duration_time=duration_minutes,
+            access_code="CODE",
+            open_at=timezone.now() - timedelta(minutes=30),
+            close_at=timezone.now() + timedelta(minutes=30),
+            questions_snapshot_json={},
+            status=ExamDeployment.StatusChoices.ACTIVATED,
+        )
+        return ExamSubmission.objects.create(
+            submitter=self.student,
+            deployment=deployment,
+            started_at=started_at,
+            cheating_count=0,
+            answers_json={},
+        )
+
+    def test_auto_submit_overdue_submission(self) -> None:
+        now = timezone.now()
+        submission = self._create_submission(
+            started_at=now - timedelta(minutes=10),
+            duration_minutes=1,
+        )
+
+        processed = auto_submit_overdue_exams()
+
+        self.assertEqual(processed, 1)
+        submission.refresh_from_db()
+        self.assertIsInstance(submission.answers_json, list)
+        self.assertGreaterEqual(len(submission.answers_json), 1)
+
+    def test_does_not_submit_if_not_overdue(self) -> None:
+        now = timezone.now()
+        submission = self._create_submission(
+            started_at=now - timedelta(minutes=1),
+            duration_minutes=30,
+        )
+
+        processed = auto_submit_overdue_exams()
+
+        self.assertEqual(processed, 0)
+        submission.refresh_from_db()
+        self.assertEqual(submission.answers_json, {})

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ["celery_app"]

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,0 +1,9 @@
+import os
+
+from celery import Celery  # type: ignore[import-untyped]
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+
+app = Celery("config")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -32,6 +32,7 @@ THIRD_PARTY_APPS = [
     "corsheaders",
     "drf_spectacular",
     "django_filters",
+    "django_celery_beat",
 ]
 
 # 추가한 도메인별 앱을 줄바꿈, 쉼표를 사용하여 나열.
@@ -217,6 +218,20 @@ EMAIL_USE_TLS = True
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+
+# Celery Settings
+CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/0"
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = TIME_ZONE
+CELERY_BEAT_SCHEDULE = {
+    "exams-auto-submit-overdue": {
+        "task": "apps.exams.tasks.auto_submit_overdue_exams",
+        "schedule": 30.0,
+    },
+}
 
 # Twilio SMS Verify Settings
 TWILIO_ACCOUNT_SID = os.environ.get("TWILIO_ACCOUNT_SID")

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -24,6 +24,42 @@ services:
       redis:
         condition: service_healthy
 
+  celery_worker:
+    container_name: celery_worker
+    env_file:
+      - envs/.local.env
+    build:
+      context: .
+    working_dir: /oz_externship
+    command: celery -A config worker -l info
+    volumes:
+      - .:/oz_externship
+    networks:
+      - ws
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  celery_beat:
+    container_name: celery_beat
+    env_file:
+      - envs/.local.env
+    build:
+      context: .
+    working_dir: /oz_externship
+    command: celery -A config beat -l info
+    volumes:
+      - .:/oz_externship
+    networks:
+      - ws
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
   nginx:
     image: nginx:latest
     container_name: nginx


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 시험 강제제출 자동화 태스크(Celery) 추가 및 로컬 실행 구성을 반영했습니다.

## 📄 상세 내용
- [x] Celery/beat 설정 추가 및 자동 강제제출 태스크 구현
- [x] 로컬 docker-compose에 worker/beat 서비스 추가
- [x] 태스크 테스트 및 celerybeat 스케줄 파일 gitignore 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
