### PR TITLE
[refactor/exams-presigned-url] fix    : url 저장방식 수정

### DIFF
--- a/apps/exams/serializers/admin/exams_create.py
+++ b/apps/exams/serializers/admin/exams_create.py
@@ -4,27 +4,18 @@ from typing import Any
 
 from rest_framework import serializers
 
-from apps.exams.constants import ErrorMessages
-
 
 class AdminExamCreateRequestSerializer(serializers.Serializer[Any]):
     """쪽지시험 생성 요청 스키마."""
 
     title = serializers.CharField(max_length=50)
     subject_id = serializers.IntegerField()
-    thumbnail_img = serializers.ImageField(
+    thumbnail_img_url = serializers.CharField(
         required=False,
+        allow_blank=True,
         allow_null=True,
-        help_text="썸네일 이미지(선택)",
+        help_text="썸네일 이미지 URL(선택)",
     )
-
-    def validate_thumbnail_img(self, value: Any) -> Any:
-        if value in (None, ""):
-            return value
-        content_type = getattr(value, "content_type", None)
-        if content_type not in {"image/jpeg", "image/png", "image/jpg"}:
-            raise serializers.ValidationError(ErrorMessages.INVALID_EXAM_CREATE_REQUEST.value)
-        return value
 
 
 class AdminExamCreateResponseSerializer(serializers.Serializer[Any]):

--- a/apps/exams/services/admin/exams_create.py
+++ b/apps/exams/services/admin/exams_create.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-import os
-from uuid import uuid4
-
-from django.core.files.storage import default_storage
-from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
 
 from apps.courses.models.subjects import Subject
@@ -13,37 +8,19 @@ from apps.exams.error_map import raise_error
 from apps.exams.models.exams import Exam
 
 
-def _store_thumbnail(thumbnail_img: UploadedFile) -> tuple[str, str]:
-    name = thumbnail_img.name or "thumbnail"
-    _, ext = os.path.splitext(name)
-    ext = ext.lower() if ext else ".png"
-    filename = f"exams/{uuid4().hex}{ext}"
-    saved_path = default_storage.save(filename, thumbnail_img)
-    return saved_path, default_storage.url(saved_path)
-
-
-def create_exam(title: str, subject_id: int, thumbnail_img: UploadedFile | None) -> Exam:
+def create_exam(title: str, subject_id: int, thumbnail_img_url: str | None) -> Exam:
     with transaction.atomic():
         subject = Subject.objects.filter(id=subject_id).first()
         if not subject:
             raise_error(ErrorMessages.SUBJECT_NOT_FOUND)
 
-        saved_path = None
-        thumbnail_img_url = None
-        if thumbnail_img is not None:
-            saved_path, thumbnail_img_url = _store_thumbnail(thumbnail_img)
-        try:
-            exam, created = Exam.objects.get_or_create(
-                title=title,
-                defaults={
-                    "subject": subject,
-                    **({"thumbnail_img_url": thumbnail_img_url} if thumbnail_img_url else {}),
-                },
-            )
-            if not created:
-                raise_error(ErrorMessages.EXAM_CONFLICT)
-            return exam
-        except Exception:
-            if saved_path:
-                default_storage.delete(saved_path)
-            raise
+        exam, created = Exam.objects.get_or_create(
+            title=title,
+            defaults={
+                "subject": subject,
+                **({"thumbnail_img_url": thumbnail_img_url} if thumbnail_img_url else {}),
+            },
+        )
+        if not created:
+            raise_error(ErrorMessages.EXAM_CONFLICT)
+        return exam

--- a/apps/exams/tests/admin/test_exams.py
+++ b/apps/exams/tests/admin/test_exams.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import tempfile
-from io import BytesIO
-from typing import Any, ClassVar
+import json
+from typing import Any
 
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase, override_settings
-from PIL import Image
+from django.test import Client, TestCase
 from rest_framework_simplejwt.tokens import AccessToken
 
 from apps.courses.models.courses import Course
@@ -19,26 +16,10 @@ from apps.users.models import User
 class AdminExamCreateAPITest(TestCase):
     """관리자 쪽지시험 생성 API 테스트."""
 
-    _temp_media: ClassVar[tempfile.TemporaryDirectory[str]]
-    _override: ClassVar[Any]
-
     course: Course
     subject: Subject
     admin_user: User
     normal_user: User
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls._temp_media = tempfile.TemporaryDirectory()
-        cls._override = override_settings(MEDIA_ROOT=cls._temp_media.name, MEDIA_URL="media/")
-        cls._override.enable()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls._override.disable()
-        cls._temp_media.cleanup()
-        super().tearDownClass()
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -84,40 +65,30 @@ class AdminExamCreateAPITest(TestCase):
         client.defaults.update(self._auth_headers(user))
         return client
 
-    def _create_image_file(self) -> SimpleUploadedFile:
-        image = Image.new("RGB", (1, 1), color="white")
-        buffer = BytesIO()
-        image.save(buffer, format="PNG")
-        return SimpleUploadedFile(
-            name="thumbnail.png",
-            content=buffer.getvalue(),
-            content_type="image/png",
-        )
+    def _post_json(self, client: Client, url: str, payload: dict[str, object]) -> Any:
+        return client.post(url, data=json.dumps(payload), content_type="application/json")
 
     def test_admin_exam_create_success(self) -> None:
-        image_file = self._create_image_file()
         data = {
             "title": "Python Basic Exam",
             "subject_id": self.subject.id,
-            "thumbnail_img": image_file,
+            "thumbnail_img_url": "https://cdn.example.com/exams/thumb.png",
         }
 
-        response = self._auth_client(self.admin_user).post(
-            "/api/v1/admin/exams",
-            data=data,
-        )
+        response = self._post_json(self._auth_client(self.admin_user), "/api/v1/admin/exams", data)
 
         self.assertEqual(response.status_code, 201)
         response_data = response.json()
         self.assertEqual(response_data["title"], data["title"])
         self.assertEqual(response_data["subject_id"], self.subject.id)
-        self.assertIn("media/", response_data["thumbnail_img_url"])
+        self.assertEqual(response_data["thumbnail_img_url"], data["thumbnail_img_url"])
         self.assertTrue(Exam.objects.filter(id=response_data["id"]).exists())
 
     def test_admin_exam_create_without_thumbnail(self) -> None:
-        response = self._auth_client(self.admin_user).post(
+        response = self._post_json(
+            self._auth_client(self.admin_user),
             "/api/v1/admin/exams",
-            data={
+            {
                 "title": "Python Basic Exam No Image",
                 "subject_id": self.subject.id,
             },
@@ -130,22 +101,23 @@ class AdminExamCreateAPITest(TestCase):
         self.assertTrue(Exam.objects.filter(id=response_data["id"]).exists())
 
     def test_admin_exam_create_returns_401_when_unauthenticated(self) -> None:
-        response = self.client.post(
+        response = self._post_json(
+            self.client,
             "/api/v1/admin/exams",
-            data={"title": "Python Basic Exam", "subject_id": self.subject.id},
+            {"title": "Python Basic Exam", "subject_id": self.subject.id},
         )
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["error_detail"], ErrorMessages.UNAUTHORIZED.value)
 
     def test_admin_exam_create_returns_403_when_not_staff(self) -> None:
-        image_file = self._create_image_file()
-        response = self._auth_client(self.normal_user).post(
+        response = self._post_json(
+            self._auth_client(self.normal_user),
             "/api/v1/admin/exams",
-            data={
+            {
                 "title": "Python Basic Exam",
                 "subject_id": self.subject.id,
-                "thumbnail_img": image_file,
+                "thumbnail_img_url": "https://cdn.example.com/exams/thumb.png",
             },
         )
 
@@ -153,13 +125,13 @@ class AdminExamCreateAPITest(TestCase):
         self.assertEqual(response.json()["error_detail"], ErrorMessages.NO_EXAM_CREATE_PERMISSION.value)
 
     def test_admin_exam_create_returns_404_when_subject_missing(self) -> None:
-        image_file = self._create_image_file()
-        response = self._auth_client(self.admin_user).post(
+        response = self._post_json(
+            self._auth_client(self.admin_user),
             "/api/v1/admin/exams",
-            data={
+            {
                 "title": "Python Basic Exam",
                 "subject_id": 9999,
-                "thumbnail_img": image_file,
+                "thumbnail_img_url": "https://cdn.example.com/exams/thumb.png",
             },
         )
 
@@ -168,14 +140,14 @@ class AdminExamCreateAPITest(TestCase):
 
     def test_admin_exam_create_returns_409_when_duplicate_title(self) -> None:
         Exam.objects.create(subject=self.subject, title="Python Basic Exam", thumbnail_img_url="media/test.png")
-        image_file = self._create_image_file()
 
-        response = self._auth_client(self.admin_user).post(
+        response = self._post_json(
+            self._auth_client(self.admin_user),
             "/api/v1/admin/exams",
-            data={
+            {
                 "title": "Python Basic Exam",
                 "subject_id": self.subject.id,
-                "thumbnail_img": image_file,
+                "thumbnail_img_url": "https://cdn.example.com/exams/thumb.png",
             },
         )
 
@@ -183,28 +155,10 @@ class AdminExamCreateAPITest(TestCase):
         self.assertEqual(response.json()["error_detail"], ErrorMessages.EXAM_CONFLICT.value)
 
     def test_admin_exam_create_returns_400_when_invalid(self) -> None:
-        response = self._auth_client(self.admin_user).post(
+        response = self._post_json(
+            self._auth_client(self.admin_user),
             "/api/v1/admin/exams",
-            data={"title": "", "subject_id": self.subject.id},
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["error_detail"], ErrorMessages.INVALID_EXAM_CREATE_REQUEST.value)
-
-    def test_admin_exam_create_returns_400_when_invalid_image_type(self) -> None:
-        image_file = SimpleUploadedFile(
-            name="thumbnail.gif",
-            content=b"GIF89a",
-            content_type="image/gif",
-        )
-
-        response = self._auth_client(self.admin_user).post(
-            "/api/v1/admin/exams",
-            data={
-                "title": "Python Basic Exam",
-                "subject_id": self.subject.id,
-                "thumbnail_img": image_file,
-            },
+            {"title": "", "subject_id": self.subject.id},
         )
 
         self.assertEqual(response.status_code, 400)

--- a/apps/exams/views/admin/exams_create.py
+++ b/apps/exams/views/admin/exams_create.py
@@ -4,7 +4,7 @@ from typing import NoReturn
 
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
-from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -25,7 +25,7 @@ class AdminExamCreateAPIView(ExamsExceptionMixin, APIView):
     """관리자 쪽지시험 생성 API."""
 
     permission_classes = [IsAuthenticated, IsStaffRole]
-    parser_classes = [MultiPartParser, FormParser, JSONParser]
+    parser_classes = [JSONParser]
     serializer_class = AdminExamCreateRequestSerializer
 
     def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
@@ -43,7 +43,7 @@ class AdminExamCreateAPIView(ExamsExceptionMixin, APIView):
         exam = create_exam(
             title=data["title"],
             subject_id=data["subject_id"],
-            thumbnail_img=data.get("thumbnail_img"),
+            thumbnail_img_url=data.get("thumbnail_img_url"),
         )
 
         response_serializer = AdminExamCreateResponseSerializer(exam)

--- a/apps/exams/views/admin/presigned_url_view.py
+++ b/apps/exams/views/admin/presigned_url_view.py
@@ -35,12 +35,12 @@ class ExamPresignedUrlAPIView(ExamsExceptionMixin, BasePresignedUrlAPIView):
     어드민 시험 썸네일 업로드용 Presigned URL 발급 API
     """
 
+    storage_target = StorageTarget.EXAM_THUMBNAIL
+
+    serializer_class = PresignedUrlRequestSerializer
+
     def get_permissions(self) -> list[Any]:
         return [IsAuthenticated(), IsStaffRole()]
-
-    parser_classes = [JSONParser]
-
-    storage_target = StorageTarget.EXAM_THUMBNAIL
 
     @extend_schema(
         summary="시험 썸네일 업로드 URL 발급",


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 시험 썸네일 업로드를 presigned URL 기반으로만 처리하도록 변경

## 📄 상세 내용
- [x] apps/exams/views/admin/presigned_url_view.py 코드 위치 변경
- [x] 시험 생성 API에서 직접 파일 업로드 제거, `thumbnail_img_url`만 수용하도록 변경
- [x] 썸네일 저장 로직을 URL 저장 방식으로 단순화
- [x] 시험 생성 관련 테스트를 JSON 요청 기준으로 갱신

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 직접 업로드 경로 제거로 프론트는 presigned URL → S3 업로드 → URL 전달 흐름만 사용

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
