### PR TITLE
🐛 fix      : started_at 서버값만 사용

### DIFF
--- a/apps/exams/serializers/student/submissions_create.py
+++ b/apps/exams/serializers/student/submissions_create.py
@@ -49,7 +49,8 @@ class ExamAnswerSerializer(serializers.Serializer[Any]):
 class ExamSubmissionCreateSerializer(serializers.Serializer[Any]):
     # 쪽지시험 제출 API 요청 데이터 검증용 Serializer
     deployment_id = serializers.IntegerField()
-    started_at = serializers.DateTimeField()
+    # started_at은 서버에서 관리한다.
+    started_at = serializers.DateTimeField(required=False)
     cheating_count = serializers.IntegerField(default=0)
     answers = ExamAnswerSerializer(many=True)
 

--- a/apps/exams/serializers/student/submissions_result.py
+++ b/apps/exams/serializers/student/submissions_result.py
@@ -41,7 +41,7 @@ class ExamSubmissionSerializer(serializers.ModelSerializer[ExamSubmission]):
 
     def get_elapsed_time(self, obj: ExamSubmission) -> int:
         seconds = (obj.created_at - obj.started_at).total_seconds()
-        return int(seconds // 60)
+        return max(0, int(seconds // 60))
 
     def _answers_map(self, obj: ExamSubmission) -> dict[int, object]:
         normalized = normalize_answers_json(obj.answers_json)

--- a/apps/exams/services/admin/submissions_detail.py
+++ b/apps/exams/services/admin/submissions_detail.py
@@ -58,7 +58,7 @@ def get_admin_submission_detail(submission_id: int) -> dict[str, Any]:
             }
         )
 
-    elapsed_time = int((submission.created_at - submission.started_at).total_seconds() // 60)
+    elapsed_time = max(0, int((submission.created_at - submission.started_at).total_seconds() // 60))
 
     return {
         "exam": {

--- a/apps/exams/services/student/submissions_create.py
+++ b/apps/exams/services/student/submissions_create.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Dict, List
 
 from django.db import transaction
@@ -17,7 +16,6 @@ def submit_exam(
     *,
     user: User,
     deployment_id: int,
-    started_at: datetime,
     cheating_count: int,
     answers: List[Dict[str, Any]],
 ) -> ExamSubmission:
@@ -38,9 +36,10 @@ def submit_exam(
         raise_error(ErrorMessages.SUBMISSION_ALREADY_SUBMITTED)
 
     # 답안 저장
+    # started_at은 take_exam 시점에 서버에서 생성된 값을 유지한다.
+    # (클라이언트 전달 시간으로 받지 않음)
     submission.answers_json = normalize_answers_json(answers)
-    submission.started_at = started_at
     submission.cheating_count = cheating_count
-    submission.save(update_fields=["answers_json", "started_at", "cheating_count", "updated_at"])
+    submission.save(update_fields=["answers_json", "cheating_count", "updated_at"])
 
     return submission

--- a/apps/exams/tests/student/test_submissions_create.py
+++ b/apps/exams/tests/student/test_submissions_create.py
@@ -98,7 +98,6 @@ class ExamSubmissionTest(APITestCase):
     def test_submission_exam_success(self) -> None:
         data = {
             "deployment_id": self.deployment.id,
-            "started_at": timezone.now().isoformat(),
             "cheating_count": 0,
             "answers": [
                 {
@@ -123,7 +122,6 @@ class ExamSubmissionTest(APITestCase):
     def test_submission_exam_invalid_type(self) -> None:
         data = {
             "deployment_id": self.deployment.id,
-            "started_at": timezone.now().isoformat(),
             "cheating_count": 0,
             "answers": [
                 {
@@ -148,7 +146,6 @@ class ExamSubmissionTest(APITestCase):
 
         data = {
             "deployment_id": self.deployment.id,
-            "started_at": timezone.now().isoformat(),
             "cheating_count": 0,
             "answers": [
                 {
@@ -173,7 +170,6 @@ class ExamSubmissionTest(APITestCase):
 
         data = {
             "deployment_id": self.deployment.id,
-            "started_at": timezone.now().isoformat(),
             "cheating_count": 0,
             "answers": [
                 {
@@ -195,7 +191,6 @@ class ExamSubmissionTest(APITestCase):
     def test_submission_exam_empty_answers(self) -> None:
         data = {
             "deployment_id": self.deployment.id,
-            "started_at": timezone.now().isoformat(),
             "cheating_count": 0,
             "answers": [],
         }

--- a/apps/exams/views/student/submissions_create.py
+++ b/apps/exams/views/student/submissions_create.py
@@ -102,7 +102,6 @@ class ExamSubmissionCreateAPIView(ExamsExceptionMixin, APIView):
         submission = submit_exam(
             user=request.user,  # type: ignore
             deployment_id=serializer.validated_data["deployment_id"],
-            started_at=serializer.validated_data["started_at"],
             cheating_count=serializer.validated_data["cheating_count"],
             answers=serializer.validated_data["answers"],
         )


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: started_at 서버에서 받은 시간으로 한정

## 📄 상세 내용
- [x] started_at을 클라이언트가 전달하면 덮어씌우는 구조 -> 서버값만 사용

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).