### PR TITLE
🐛 fix: 어드민 응시 내역 상세 elapsed_time 초 단위로 일관화

### DIFF
--- a/apps/exams/serializers/student/submissions_result.py
+++ b/apps/exams/serializers/student/submissions_result.py
@@ -40,8 +40,7 @@ class ExamSubmissionSerializer(serializers.ModelSerializer[ExamSubmission]):
         read_only_fields = fields
 
     def get_elapsed_time(self, obj: ExamSubmission) -> int:
-        seconds = (obj.created_at - obj.started_at).total_seconds()
-        return max(0, int(seconds // 60))
+        return max(0, int((obj.created_at - obj.started_at).total_seconds()))
 
     def _answers_map(self, obj: ExamSubmission) -> dict[int, object]:
         normalized = normalize_answers_json(obj.answers_json)

--- a/apps/exams/services/admin/submissions_detail.py
+++ b/apps/exams/services/admin/submissions_detail.py
@@ -58,7 +58,7 @@ def get_admin_submission_detail(submission_id: int) -> dict[str, Any]:
             }
         )
 
-    elapsed_time = max(0, int((submission.created_at - submission.started_at).total_seconds() // 60))
+    elapsed_time = max(0, int((submission.created_at - submission.started_at).total_seconds()))
 
     return {
         "exam": {

--- a/apps/exams/tests/admin/test_submissions_detail.py
+++ b/apps/exams/tests/admin/test_submissions_detail.py
@@ -116,7 +116,7 @@ class AdminExamSubmissionDetailAPITest(TestCase):
             score=10,
             correct_answer_count=1,
         )
-        cls.expected_elapsed = int((cls.submission.created_at - started_at).total_seconds() // 60)
+        cls.expected_elapsed = int((cls.submission.created_at - started_at).total_seconds())
 
     def _auth_headers(self, user: User) -> dict[str, str]:
         token = AccessToken.for_user(user)
@@ -178,3 +178,23 @@ class AdminExamSubmissionDetailAPITest(TestCase):
         self.assertEqual(response.status_code, 404)
         data = response.json()
         self.assertEqual(data["error_detail"], ErrorMessages.SUBMISSION_DETAIL_NOT_FOUND.value)
+
+    def test_elapsed_time_is_calculated_in_seconds(self) -> None:
+        started_at = timezone.make_aware(datetime(2025, 3, 2, 10, 0, 0))
+        created_at = started_at + timedelta(seconds=27)
+        updated_at = started_at + timedelta(minutes=10)
+
+        ExamSubmission.objects.filter(id=self.submission.id).update(
+            started_at=started_at,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        response = self.client.get(
+            f"/api/v1/admin/exams/submissions/{self.submission.id}",
+            headers=self._auth_headers(self.admin_user),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["result"]["elapsed_time"], 27)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 없음
- 작업 요약: 어드민 응시 내역 상세 조회의 `elapsed_time` 계산 기준을 초 단위로 통일하고, 관련 테스트를 보강했습니다.

## 📄 상세 내용
- [x] `elapsed_time` 계산을 분 단위(`// 60`)에서 초 단위(`total_seconds`)로 변경
- [x] 테스트의 기대값을 초 단위 기준으로 수정
- [x] `elapsed_time`이 초 단위로 계산됨을 보장하는 테스트 추가

## 📸 스크린샷 (선택)
- 없음

## 📝 기타 참고 사항
- started_at/created_at를 3분 30초 차이로 맞춘 뒤 실제 상세 서비스가 반환하는 elapsed_time 확인시 elapsed_time=210 확인

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
