### PR TITLE
[flx/elapsed_time_2] 🐛 fix: 시험 제출 시 created_at을 제출 시점으로 갱신

### DIFF
--- a/apps/exams/services/student/submissions_create.py
+++ b/apps/exams/services/student/submissions_create.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from django.db import transaction
+from django.utils import timezone
 
 from apps.exams.constants import ErrorMessages
 from apps.exams.error_map import raise_error
@@ -36,10 +37,10 @@ def submit_exam(
         raise_error(ErrorMessages.SUBMISSION_ALREADY_SUBMITTED)
 
     # 답안 저장
-    # started_at은 take_exam 시점에 서버에서 생성된 값을 유지한다.
-    # (클라이언트 전달 시간으로 받지 않음)
+    now = timezone.now()
+    submission.created_at = now
     submission.answers_json = normalize_answers_json(answers)
     submission.cheating_count = cheating_count
-    submission.save(update_fields=["answers_json", "cheating_count", "updated_at"])
+    submission.save(update_fields=["answers_json", "cheating_count", "created_at", "updated_at"])
 
     return submission


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 시험 제출 시 created_at을 제출 시점으로 갱신

## 📄 상세 내용
- [x] 시험 제출 로직에서 timezone.now()를 사용해 created_at을 제출 시점으로 설정
- [x] 제출 저장 시 update_fields에 created_at을 포함하여 응시 시간 계산 기준을 보정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
응시 시작시 submission 객체가 생성되어 auto_now_add 옵션인 created_at 또한 함께 생성됨.
started_at=created_at이 되어버리기에 created_at에 제출시점의 시간을 강제삽입함.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
