### PR TITLE
[accounts/withdrawal-delete] 회원탈퇴 API를 DELETE 메서드로 변경

### DIFF
--- a/apps/users/tests/test_admin_accounts.py
+++ b/apps/users/tests/test_admin_accounts.py
@@ -41,7 +41,11 @@ class AdminUserListViewTest(APITestCase):
         cls.withdrawn_user = User.objects.create_user(
             email="withdrew@test.com", password="password123", nickname="withdrew", role="USER", birthday="1990-01-01"
         )
-        Withdrawal.objects.create(user=cls.withdrawn_user, reason="Test reason")
+        Withdrawal.objects.create(
+            user=cls.withdrawn_user,
+            reason=Withdrawal.Reason.OTHER,  # 또는 SERVICE_DISSATISFACTION 등
+            reason_detail="테스트용 탈퇴 계정",
+        )
 
         cls.url = reverse("admin-account-list")
 

--- a/apps/users/tests/test_login.py
+++ b/apps/users/tests/test_login.py
@@ -69,7 +69,11 @@ class LoginAPITests(TestCase):
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_login_withdrawal_account_403(self) -> None:
-        Withdrawal.objects.create(user=self.user, reason="SERVICE_DISSATISFACTION")
+        Withdrawal.objects.create(
+            user=self.user,
+            reason="SERVICE_DISSATISFACTION",
+            reason_detail="테스트용 탈퇴",
+        )
 
         res = self.client.post(
             self.url,

--- a/apps/users/tests/test_me.py
+++ b/apps/users/tests/test_me.py
@@ -92,7 +92,7 @@ class MeAPITests(TestCase):
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_withdrawal_success_204_and_user_inactive(self) -> None:
-        res = self.client.post(
+        res = self.client.delete(
             "/api/v1/accounts/withdrawal/",
             {"reason": "PRIVACY_CONCERN", "reason_detail": "테스트 탈퇴"},
             format="json",
@@ -105,7 +105,7 @@ class MeAPITests(TestCase):
         self.assertTrue(Withdrawal.objects.filter(user=self.user).exists())
 
     def test_withdrawal_invalid_reason_400(self) -> None:
-        res = self.client.post(
+        res = self.client.delete(
             "/api/v1/accounts/withdrawal/",
             {"reason": "INVALID", "reason_detail": "테스트"},
             format="json",
@@ -113,9 +113,13 @@ class MeAPITests(TestCase):
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_withdrawal_already_requested_400(self) -> None:
-        Withdrawal.objects.create(user=self.user, reason="SERVICE_DISSATISFACTION")
+        Withdrawal.objects.create(
+            user=self.user,
+            reason="SERVICE_DISSATISFACTION",
+            reason_detail="이미 탈퇴 신청된 상태",
+        )
 
-        res = self.client.post(
+        res = self.client.delete(
             "/api/v1/accounts/withdrawal/",
             {"reason": "PRIVACY_CONCERN", "reason_detail": "테스트"},
             format="json",
@@ -128,7 +132,7 @@ class MeAPITests(TestCase):
     def test_withdrawal_unauthenticated_401(self) -> None:
         self.client.credentials()
 
-        res = self.client.post(
+        res = self.client.delete(
             "/api/v1/accounts/withdrawal/",
             {"reason": "PRIVACY_CONCERN", "reason_detail": "테스트"},
             format="json",

--- a/apps/users/tests/test_restore.py
+++ b/apps/users/tests/test_restore.py
@@ -38,6 +38,8 @@ class RestoreAPITest(TestCase):
         )
         Withdrawal.objects.create(
             user=user,
+            reason="OTHER",
+            reason_detail="복구 테스트용",
             due_date=date.today() + timedelta(days=7),
         )
 

--- a/apps/users/tests/test_social_login.py
+++ b/apps/users/tests/test_social_login.py
@@ -495,7 +495,11 @@ class KakaoLoginViewTests(TestCase):
             gender=User.Gender.MALE,
             birthday=date(1990, 1, 1),
         )
-        Withdrawal.objects.create(user=withdrawn_user, reason="SERVICE_DISSATISFACTION")
+        Withdrawal.objects.create(
+            user=withdrawn_user,
+            reason="SERVICE_DISSATISFACTION",
+            reason_detail="소셜 로그인 테스트용 탈퇴",
+        )
         SocialUser.objects.create(
             user=withdrawn_user,
             provider=SocialUser.Provider.KAKAO,
@@ -641,7 +645,11 @@ class NaverLoginViewTests(TestCase):
             gender=User.Gender.MALE,
             birthday=date(1990, 1, 1),
         )
-        Withdrawal.objects.create(user=withdrawn_user, reason="SERVICE_DISSATISFACTION")
+        Withdrawal.objects.create(
+            user=withdrawn_user,
+            reason="SERVICE_DISSATISFACTION",
+            reason_detail="소셜 로그인 테스트용 탈퇴",
+        )
         SocialUser.objects.create(
             user=withdrawn_user,
             provider=SocialUser.Provider.NAVER,

--- a/apps/users/views/withdrawal_view.py
+++ b/apps/users/views/withdrawal_view.py
@@ -30,11 +30,16 @@ class WithdrawalAPIView(APIView):
             401: OpenApiResponse(description="인증되지 않은 사용자"),
         },
     )
-    def post(self, request: Request) -> Response:
+    def delete(self, request: Request) -> Response:
         serializer = WithdrawalRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         data = serializer.validated_data
         assert isinstance(request.user, User)
-        withdraw_user(user=request.user, reason=data["reason"], reason_detail=data["reason_detail"])
+
+        withdraw_user(
+            user=request.user,
+            reason=data["reason"],
+            reason_detail=data["reason_detail"],
+        )
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## ✅ PR 요약
- 회원탈퇴 API를 기존 POST 방식에서 DELETE 방식으로 변경
- 관련 테스트 코드 전부 delete()로 수정
- Withdrawal 모델 생성 시 reason_detail 필수값 누락으로 인한 테스트 실패 가능성 수정

## 📄 상세 내용
- [x] 회원탈퇴 API 메서드를 `POST` → `DELETE`로 변경하여 405 이슈 해결
- [x] 회원탈퇴 관련 테스트를 `client.post()` → `client.delete()`로 수정 (DELETE 요청 body 포함)
- [x] 테스트에서 `Withdrawal` 생성 시 `reason_detail` 필수값 누락으로 발생 가능한 오류를 수정

## 📸 스크린샷 (선택)
- (필요 시 Swagger 화면 / Network 탭 캡처 추가)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
