### PR TITLE
[Feature/comment tag] ✨ feat: 댓글 유저 태깅 기능 추가 및 Swagger 태그 posts 통합

### DIFF
--- a/apps/posts/models/post_comment.py
+++ b/apps/posts/models/post_comment.py
@@ -15,7 +15,7 @@ class PostComment(TimeStampModel):
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="post_comments", verbose_name="작성자"
     )
     post = models.ForeignKey("posts.Post", on_delete=models.CASCADE, related_name="comments", verbose_name="게시글")
-    content = models.CharField(max_length=300, null=False, verbose_name="내용")
+    content = models.CharField(max_length=500, null=False, verbose_name="내용")
 
     class Meta:
         db_table = "post_comment"

--- a/apps/posts/serializers/comment_serializers.py
+++ b/apps/posts/serializers/comment_serializers.py
@@ -18,7 +18,8 @@ from apps.posts.services.comment.comment_update_services import update_comment
 
 class TaggedUserSerializer(serializers.ModelSerializer[PostCommentTag]):
     """
-    댓글에 태그된 사용자 정보를 반환하는 시리얼라이저입니다.
+    댓글 내 태그된 개별 사용자 정보를 직렬화하는 시리얼라이저입니다.
+    PostCommentTag 모델의 정보를 클라이언트가 필요한 유저 정보로 변환합니다.
     """
 
     id = serializers.IntegerField(source="tagged_user.id")  # 태그된 사용자의 PK
@@ -31,20 +32,20 @@ class TaggedUserSerializer(serializers.ModelSerializer[PostCommentTag]):
 
 class PostCommentListSerializer(serializers.ModelSerializer[PostComment]):
     """
-    댓글 목록을 조회할 때 사용하는 시리얼라이저입니다.
+    게시글의 댓글 목록을 조회할 때 사용되는 시리얼라이저입니다.
+    기본 댓글 정보와 함께 작성자 정보 및 태그된 유저 목록을 포함합니다.
     """
 
-    author = PostAuthorSerializer(read_only=True)  # 댓글 작성자 정보
-    tagged_users = serializers.SerializerMethodField()  # 태그된 사용자 목록
+    author = PostAuthorSerializer(read_only=True)  # 댓글 작성자 정보 (ID, 닉네임, 프로필)
+
+    # 태그된 유저 목록 처리:
+    # - source="tags": PostComment 모델의 'tags' related_name을 참조합니다.
+    # - many=True: 여러 명의 유저가 태그될 수 있음을 나타냅니다.
+    tagged_users = TaggedUserSerializer(source="tags", many=True, read_only=True)
 
     class Meta:
         model = PostComment
         fields = ("id", "author", "tagged_users", "content", "created_at", "updated_at")
-
-    def get_tagged_users(self, obj: PostComment) -> Any:
-        # 댓글에 태그된 사용자 목록을 반환합니다.
-        tags = obj.tags.all()
-        return TaggedUserSerializer(tags, many=True).data
 
 
 class PostCommentCreateSerializer(serializers.Serializer[PostComment]):

--- a/apps/posts/services/comment/comment_create_services.py
+++ b/apps/posts/services/comment/comment_create_services.py
@@ -4,16 +4,25 @@ from django.db import transaction
 
 from apps.posts.models.post import Post
 from apps.posts.models.post_comment import PostComment
+from apps.posts.services.comment.comment_tagging_services import process_comment_tagging
 
 
 @transaction.atomic
 def create_comment(author: Any, post: Post, content: str) -> PostComment:
     """
-    댓글 생성
+    새로운 댓글을 생성하고, 본문 내 유저 태깅을 처리합니다.
 
-    @transaction.atomic:
-    - 댓글 생성과 관련된 모든 DB 작업을 하나의 트랜잭션으로 묶음
-    - 에러 발생 시 자동 롤백하여 데이터 일관성 보장
-    - 향후 알림, 통계 업데이트 등 추가 작업 시에도 안전성 유지
+    Args:
+        author (Any): 댓글 작성자 (User 객체)
+        post (Post): 댓글이 달릴 게시글 객체
+        content (str): 댓글 본문 내용
+    Returns:
+        PostComment: 생성된 댓글 객체
     """
-    return PostComment.objects.create(author=author, post=post, content=content)
+    # 1. 댓글 기본 정보를 DB에 저장합니다.
+    comment = PostComment.objects.create(author=author, post=post, content=content)
+
+    # 2. 본문 텍스트를 분석하여 태깅된 유저 정보를 저장합니다.
+    process_comment_tagging(comment, content)
+
+    return comment

--- a/apps/posts/services/comment/comment_tagging_services.py
+++ b/apps/posts/services/comment/comment_tagging_services.py
@@ -1,0 +1,52 @@
+import re
+from typing import Set
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+
+from apps.posts.models.post_comment import PostComment
+
+UserModel = get_user_model()
+
+
+def process_comment_tagging(comment: PostComment, content: str) -> None:
+    """
+    댓글 본문에서 유저 태깅(@닉네임) 패턴을 분석하여 처리하는 서비스 함수입니다.
+
+    작동 원리:
+    1. 정규표현식을 이용해 본문 내 모든 '@닉네임' 형태를 추출합니다.
+    2. 기존에 저장된 태그 정보가 있다면 데이터 정합성을 위해 모두 삭제합니다(갱신 로직).
+    3. 추출된 닉네임 중 실제 DB에 존재하는 유저들을 조회하여 매핑합니다.
+    4. 대량의 태그가 발생할 경우를 대비하여 bulk_create로 성능을 최적화합니다.
+
+    Args:
+        comment (PostComment): 태그가 연결될 댓글 객체
+        content (str): 분석할 댓글 본문 텍스트
+    """
+    # [단계 1] 본문에서 @닉네임 패턴 추출
+    # - r"@([^\s@]+)": @로 시작하고, 그 뒤에 공백(\s)이나 @가 아닌 문자들을 하나 이상(+) 캡처합니다.
+    # - set()을 사용하여 중복된 닉네임 언급은 한 번만 처리하도록 합니다.
+    nicknames: Set[str] = set(re.findall(r"@([^\s@]+)", content))
+
+    # 데이터 변경 작업이므로 원자성(Atomic)을 보장합니다.
+    with transaction.atomic():
+        # [단계 2] 기존 태그 정보 초기화
+        # 댓글 수정 시 태그가 추가되거나 삭제될 수 있으므로, 기존 데이터를 삭제하고 최신 상태로 재구축합니다.
+        comment.tags.all().delete()
+
+        # 언급된 닉네임이 없다면 처리를 종료합니다.
+        if not nicknames:
+            return
+
+        # [단계 3] 실제 존재하는 유저인지 DB 확인
+        # - 닉네임으로 유저 모델을 조회하며, 존재하지 않는 닉네임 언급은 무시됩니다.
+        tagged_users = UserModel.objects.filter(nickname__in=nicknames)
+
+        # [단계 4] 새로운 태그 정보 일괄 생성
+        from apps.posts.models.post_comment_tags import PostCommentTag
+
+        # 리스트 컴프리헨션을 사용하여 PostCommentTag 객체 목록을 생성합니다.
+        tags = [PostCommentTag(comment=comment, tagged_user=user) for user in tagged_users]
+
+        # 성능을 위해 여러 개의 레코드를 한 번의 쿼리로 삽입합니다.
+        PostCommentTag.objects.bulk_create(tags)

--- a/apps/posts/services/comment/comment_update_services.py
+++ b/apps/posts/services/comment/comment_update_services.py
@@ -4,19 +4,33 @@ from django.db import transaction
 
 from apps.posts.exceptions.comment_exceptions import CommentForbiddenException
 from apps.posts.models.post_comment import PostComment
+from apps.posts.services.comment.comment_tagging_services import process_comment_tagging
 
 
 @transaction.atomic
 def update_comment(user: Any, comment: PostComment, content: str) -> PostComment:
     """
-    댓글 수정 (작성자만 가능)
+    기존 댓글의 내용을 수정하고, 변경된 본문에 따라 유저 태깅 정보를 갱신합니다.
 
-    @transaction.atomic:
-    - 댓글 수정과 관련된 모든 DB 작업을 하나의 트랜잭션으로 묶음
-    - 에러 발생 시 자동 롤백하여 데이터 일관성 보장
+    Args:
+        user (Any): 수정을 시도하는 사용자 객체
+        comment (PostComment): 수정 대상 댓글 객체
+        content (str): 새로운 댓글 본문 내용
+    Returns:
+        PostComment: 수정 완료된 댓글 객체
+    Raises:
+        CommentForbiddenException: 요청자가 작성자가 아닐 경우 발생
     """
+    # 1. 권한 검증: 댓글 작성자 본인인지 확인합니다.
     if comment.author != user:
         raise CommentForbiddenException()
+
+    # 2. 본문 내용을 수정하고 수정 시각을 갱신합니다.
     comment.content = content
     comment.save(update_fields=["content", "updated_at"])
+
+    # 3. 변경된 본문에 맞춰 태깅 정보를 최신화합니다.
+    # (내부적으로 기존 태그 삭제 후 재성성 프로세스 진행)
+    process_comment_tagging(comment, content)
+
     return comment

--- a/apps/posts/tests/comment/test_comment_tagging.py
+++ b/apps/posts/tests/comment/test_comment_tagging.py
@@ -1,0 +1,89 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.posts.models.post import Post
+from apps.posts.models.post_category import PostCategory
+from apps.posts.models.post_comment import PostComment
+from apps.posts.models.post_comment_tags import PostCommentTag
+
+User = get_user_model()
+
+
+class CommentTaggingTests(APITestCase):
+    """댓글 유저 태깅 기능 테스트"""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="password",
+            nickname="testuser",
+            phone_number="010-1111-2222",
+            gender="MALE",
+            birthday="1990-01-01",
+        )
+        self.other_user = User.objects.create_user(
+            email="other@example.com",
+            password="password",
+            nickname="taggeduser",
+            phone_number="010-3333-4444",
+            gender="FEMALE",
+            birthday="1992-02-02",
+        )
+        self.category = PostCategory.objects.create(name="test category")
+        self.post = Post.objects.create(
+            author=self.user,
+            title="test post",
+            content="test content",
+            category=self.category,
+        )
+        self.client.force_authenticate(user=self.user)
+        self.list_url = reverse("posts:post-comment-list-create", args=[self.post.id])
+
+    def test_create_comment_with_tag(self) -> None:
+        """댓글 작성 시 유저 태그가 정상적으로 저장되는지 테스트"""
+        content = "@taggeduser 안녕하세요!"
+        data = {"content": content}
+        response = self.client.post(self.list_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # 댓글 및 태그 생성 확인
+        comment = PostComment.objects.get(post=self.post, content=content)
+        tags = PostCommentTag.objects.filter(comment=comment)
+        self.assertEqual(tags.count(), 1)
+        tag = tags.first()
+        self.assertIsNotNone(tag)
+        if tag:
+            self.assertEqual(tag.tagged_user, self.other_user)
+
+    def test_update_comment_tag(self) -> None:
+        """댓글 수정 시 유저 태그가 갱신되는지 테스트"""
+        comment = PostComment.objects.create(post=self.post, author=self.user, content="기존 내용")
+        detail_url = reverse("posts:post-comment-detail", args=[self.post.id, comment.id])
+
+        # 새로운 태그로 수정
+        new_content = "@taggeduser 수정된 내용"
+        response = self.client.put(detail_url, {"content": new_content})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        comment.refresh_from_db()
+        self.assertEqual(comment.content, new_content)
+
+        tags = PostCommentTag.objects.filter(comment=comment)
+        self.assertEqual(tags.count(), 1)
+        tag = tags.first()
+        self.assertIsNotNone(tag)
+        if tag:
+            self.assertEqual(tag.tagged_user, self.other_user)
+
+    def test_invalid_user_tag_ignored(self) -> None:
+        """존재하지 않는 유저 태그 시 무시되는지 테스트"""
+        content = "@noneuser 존재하지 않는 유저"
+        data = {"content": content}
+        response = self.client.post(self.list_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        comment = PostComment.objects.get(post=self.post, content=content)
+        self.assertFalse(PostCommentTag.objects.filter(comment=comment).exists())

--- a/apps/posts/views/comment/comment_create_views.py
+++ b/apps/posts/views/comment/comment_create_views.py
@@ -42,7 +42,7 @@ class PostCommentCreateAPIView(CommentBaseView, generics.CreateAPIView[PostComme
         return ctx
 
     @extend_schema(
-        tags=["Comments"],
+        tags=["posts"],
         summary="커뮤니티 게시글 댓글 작성 API",
         request=PostCommentCreateSerializer,
         responses={

--- a/apps/posts/views/comment/comment_delete_views.py
+++ b/apps/posts/views/comment/comment_delete_views.py
@@ -38,7 +38,7 @@ class PostCommentDeleteAPIView(CommentBaseView, APIView):
         return comment_id
 
     @extend_schema(
-        tags=["Comments"],
+        tags=["posts"],
         summary="댓글 삭제 API",
         responses={
             200: inline_serializer(name="PostCommentDelete200", fields={"detail": serializers.CharField()}),

--- a/apps/posts/views/comment/comment_update_views.py
+++ b/apps/posts/views/comment/comment_update_views.py
@@ -43,7 +43,7 @@ class PostCommentUpdateAPIView(CommentBaseView, APIView):
         return comment_id
 
     @extend_schema(
-        tags=["Comments"],
+        tags=["posts"],
         summary="댓글 수정 API",
         responses={
             200: inline_serializer(


### PR DESCRIPTION
## ✅ PR 요약
✨ feat: 댓글 유저 태깅 기능 추가 및 Swagger 태그 posts 통합

## 📄 상세 내용
- 댓글 본문 내 유저 태그하는 기능 구현 (REQ-CMNT-008)
- 댓글 목록 조회 시 태그된 유저 정보(id, nickname) 포함 (REQ-CMNT-009)
- 모든 댓글 관련 API 태그를 'posts'로 통합
- PostComment 모델의 content 최대 길이를 요구사항에 맞춰 500자로 조정
- comment_tagging_services 분리 및 관련 서비스(create, update) 연동

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
